### PR TITLE
IRISHUB-9：The BroadcastTxAsync replaced with BroadcastTxSync

### DIFF
--- a/app/context.go
+++ b/app/context.go
@@ -13,6 +13,10 @@ func (c Context) BroadcastTxAsync(tx []byte) (*ctypes.ResultBroadcastTx, error) 
 	return c.ctx.Client.BroadcastTxAsync(tx)
 }
 
+func (c Context) BroadcastTxSync(tx []byte) (*ctypes.ResultBroadcastTx, error) {
+	return c.ctx.Client.BroadcastTxSync(tx)
+}
+
 func (c Context) GetCosmosCtx() (context.CoreContext) {
 	return c.ctx
 }

--- a/cmd/iriscli/offline_sign.go
+++ b/cmd/iriscli/offline_sign.go
@@ -74,7 +74,7 @@ func SendTxRequestHandlerFn(cdc *wire.Codec, kb keys.Keybase, ctx app.Context) h
 		}
 		txByte,_ := cdc.MarshalBinary(stdTx)
 		// send
-		res, err := ctx.BroadcastTxAsync(txByte)
+		res, err := ctx.BroadcastTxSync(txByte)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			w.Write([]byte(err.Error()))


### PR DESCRIPTION
The BroadcastTxAsync method should not be used and should be replaced with BroadcastTxSync. the reason:
The return result of BroadcastTxAsync has not passed the checkTx process of the app, and the illegal transaction cannot be found in time;
The result of BroadcastTxSync is passed through the app's checkTx process, which ensures that the transaction is executed correctly unless unexpected.