### PR TITLE
IRISHUB-256: improve api docs and convert all token to its main unit

### DIFF
--- a/client/bank/lcd/rest.go
+++ b/client/bank/lcd/rest.go
@@ -1,7 +1,6 @@
 package lcd
 
 import (
-	"github.com/cosmos/cosmos-sdk/crypto/keys"
 	"github.com/cosmos/cosmos-sdk/wire"
 	authcmd "github.com/cosmos/cosmos-sdk/x/auth/client/cli"
 	"github.com/gorilla/mux"
@@ -9,8 +8,8 @@ import (
 )
 
 // RegisterRoutes - Central function to define routes that get registered by the main application
-func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router, cdc *wire.Codec, kb keys.Keybase) {
-	r.HandleFunc("/bank/{address}/send", SendRequestHandlerFn(cdc, kb, cliCtx)).Methods("POST")
+func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router, cdc *wire.Codec) {
+	r.HandleFunc("/bank/{address}/send", SendRequestHandlerFn(cdc, cliCtx)).Methods("POST")
 	r.HandleFunc("/bank/accounts/{address}",
 		QueryAccountRequestHandlerFn("acc", cdc, authcmd.GetAccountDecoder(cdc), cliCtx)).Methods("GET")
 	r.HandleFunc("/bank/coin/{coin-type}",

--- a/client/bank/lcd/sendtx.go
+++ b/client/bank/lcd/sendtx.go
@@ -1,7 +1,6 @@
 package lcd
 
 import (
-	"github.com/cosmos/cosmos-sdk/crypto/keys"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/wire"
 	"github.com/gorilla/mux"
@@ -19,7 +18,7 @@ type sendBody struct {
 
 // SendRequestHandlerFn - http request handler to send coins to a address
 // nolint: gocyclo
-func SendRequestHandlerFn(cdc *wire.Codec, kb keys.Keybase, cliCtx context.CLIContext) http.HandlerFunc {
+func SendRequestHandlerFn(cdc *wire.Codec, cliCtx context.CLIContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// collect data
 		vars := mux.Vars(r)

--- a/client/bank/lcd/sendtx.go
+++ b/client/bank/lcd/sendtx.go
@@ -12,7 +12,7 @@ import (
 )
 
 type sendBody struct {
-	Amount sdk.Coins      `json:"amount"`
+	Amount string         `json:"amount"`
 	Sender string         `json:"sender"`
 	BaseTx context.BaseTx `json:"base_tx"`
 }
@@ -46,7 +46,7 @@ func SendRequestHandlerFn(cdc *wire.Codec, kb keys.Keybase, cliCtx context.CLICo
 			return
 		}
 
-		amount, err := cliCtx.ParseCoins(m.Amount.String())
+		amount, err := cliCtx.ParseCoins(m.Amount)
 		if err != nil {
 			utils.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return

--- a/client/context/context.go
+++ b/client/context/context.go
@@ -94,13 +94,14 @@ func createCertifier() tmlite.Certifier {
 		errMsg.WriteString("--node ")
 	}
 	if errMsg.Len() != 0 {
-		fmt.Printf("must specify these options: %s when --trust-node is false\n", errMsg.String())
+		fmt.Printf("Must specify these options: %s when --trust-node is false\n", errMsg.String())
 		os.Exit(1)
 	}
 
 	certifier, err := tmliteProxy.GetCertifier(chainID, home, nodeURI)
 	if err != nil {
-		panic(err)
+		fmt.Printf("Abort!! IRISLCD encountered fatal error in creating certifier: %s", err.Error())
+		os.Exit(1)
 	}
 
 	return certifier

--- a/client/gov/cli/query.go
+++ b/client/gov/cli/query.go
@@ -32,7 +32,7 @@ func GetCmdQueryProposal(storeName string, cdc *wire.Codec) *cobra.Command {
 			var proposal gov.Proposal
 			cdc.MustUnmarshalBinary(res, &proposal)
 
-			proposalResponse, err := govClient.ConvertProposalCoins(cliCtx, proposal)
+			proposalResponse, err := govClient.ConvertProposalToProposalOutput(cliCtx, proposal)
 			if err != nil {
 				return err
 			}
@@ -98,7 +98,7 @@ func GetCmdQueryProposals(storeName string, cdc *wire.Codec) *cobra.Command {
 			var maxProposalID int64
 			cdc.MustUnmarshalBinary(res, &maxProposalID)
 
-			matchingProposals := []govClient.TextProposalResponse{}
+			matchingProposals := []govClient.ProposalOutput{}
 
 			if latestProposalsIDs == 0 {
 				latestProposalsIDs = maxProposalID
@@ -133,7 +133,7 @@ func GetCmdQueryProposals(storeName string, cdc *wire.Codec) *cobra.Command {
 					}
 				}
 
-				proposalResponse, err := govClient.ConvertProposalCoins(cliCtx, proposal)
+				proposalResponse, err := govClient.ConvertProposalToProposalOutput(cliCtx, proposal)
 				if err != nil {
 					return err
 				}

--- a/client/gov/common.go
+++ b/client/gov/common.go
@@ -7,13 +7,13 @@ import (
 )
 
 // Deposit
-type DepositResponse struct {
+type DepositOutput struct {
 	Depositer  sdk.AccAddress `json:"depositer"`   //  Address of the depositer
 	ProposalID int64          `json:"proposal_id"` //  proposalID of the proposal
 	Amount     []string       `json:"amount"`      //  Deposit amount
 }
 
-type TextProposalResponse struct {
+type ProposalOutput struct {
 	ProposalID   int64            `json:"proposal_id"`   //  ID of the proposal
 	Title        string           `json:"title"`         //  Title of the proposal
 	Description  string           `json:"description"`   //  Description of the proposal
@@ -33,12 +33,12 @@ type KvPair struct {
 	V string `json:"value"`
 }
 
-func ConvertProposalCoins(cliCtx context.CLIContext, proposal gov.Proposal) (TextProposalResponse, error) {
+func ConvertProposalToProposalOutput(cliCtx context.CLIContext, proposal gov.Proposal) (ProposalOutput, error) {
 	totalDeposit, err := cliCtx.ConvertCoinToMainUnit(proposal.GetTotalDeposit().String())
 	if err != nil {
-		return TextProposalResponse{}, err
+		return ProposalOutput{}, err
 	}
-	return TextProposalResponse{
+	return ProposalOutput{
 		ProposalID:   proposal.GetProposalID(),
 		Title:        proposal.GetTitle(),
 		Description:  proposal.GetDescription(),
@@ -54,12 +54,12 @@ func ConvertProposalCoins(cliCtx context.CLIContext, proposal gov.Proposal) (Tex
 	}, nil
 }
 
-func ConvertDepositeCoins(cliCtx context.CLIContext, deposite gov.Deposit) (DepositResponse, error) {
+func ConvertDepositToDepositOutput(cliCtx context.CLIContext, deposite gov.Deposit) (DepositOutput, error) {
 	amount, err := cliCtx.ConvertCoinToMainUnit(deposite.Amount.String())
 	if err != nil {
-		return DepositResponse{}, err
+		return DepositOutput{}, err
 	}
-	return DepositResponse{
+	return DepositOutput{
 		ProposalID: deposite.ProposalID,
 		Depositer:  deposite.Depositer,
 		Amount:     amount,

--- a/client/gov/lcd/query.go
+++ b/client/gov/lcd/query.go
@@ -37,7 +37,7 @@ func queryProposalHandlerFn(cdc *wire.Codec, cliCtx context.CLIContext) http.Han
 
 		var proposal gov.Proposal
 		cdc.MustUnmarshalBinary(res, &proposal)
-		proposalResponse, err := govClient.ConvertProposalCoins(cliCtx, proposal)
+		proposalResponse, err := govClient.ConvertProposalToProposalOutput(cliCtx, proposal)
 		if err != nil {
 			utils.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
 			return
@@ -96,7 +96,7 @@ func queryDepositHandlerFn(cdc *wire.Codec, cliCtx context.CLIContext) http.Hand
 		var deposit gov.Deposit
 		cdc.MustUnmarshalBinary(res, &deposit)
 
-		depositeResponse, err := govClient.ConvertDepositeCoins(cliCtx, deposit)
+		depositeResponse, err := govClient.ConvertDepositToDepositOutput(cliCtx, deposit)
 		if err != nil {
 			utils.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
 			return
@@ -266,7 +266,7 @@ func queryProposalsWithParameterFn(cdc *wire.Codec, cliCtx context.CLIContext) h
 		var maxProposalID int64
 		cdc.MustUnmarshalBinary(res, &maxProposalID)
 
-		matchingProposals := []govClient.TextProposalResponse{}
+		matchingProposals := []govClient.ProposalOutput{}
 
 		for proposalID := int64(0); proposalID < maxProposalID; proposalID++ {
 			if voterAddr != nil {
@@ -296,7 +296,7 @@ func queryProposalsWithParameterFn(cdc *wire.Codec, cliCtx context.CLIContext) h
 					continue
 				}
 			}
-			proposalResponse, err := govClient.ConvertProposalCoins(cliCtx, proposal)
+			proposalResponse, err := govClient.ConvertProposalToProposalOutput(cliCtx, proposal)
 			if err != nil {
 				utils.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
 				return

--- a/client/gov/lcd/sendtx.go
+++ b/client/gov/lcd/sendtx.go
@@ -20,13 +20,13 @@ type postProposalReq struct {
 	Description    string           `json:"description"`     //  Description of the proposal
 	ProposalType   gov.ProposalKind `json:"proposal_type"`   //  Type of proposal. Initial set {PlainTextProposal, SoftwareUpgradeProposal}
 	Proposer       string           `json:"proposer"`        //  Address of the proposer
-	InitialDeposit sdk.Coins        `json:"initial_deposit"` // Coins to add to the proposal's deposit
+	InitialDeposit string           `json:"initial_deposit"` // Coins to add to the proposal's deposit
 }
 
 type depositReq struct {
 	BaseTx    context.BaseTx `json:"base_tx"`
 	Depositer string         `json:"depositer"` // Address of the depositer
-	Amount    sdk.Coins      `json:"amount"`    // Coins to add to the proposal's deposit
+	Amount    string         `json:"amount"`    // Coins to add to the proposal's deposit
 }
 
 type voteReq struct {
@@ -55,7 +55,7 @@ func postProposalHandlerFn(cdc *wire.Codec, cliCtx context.CLIContext) http.Hand
 			return
 		}
 
-		initDepositAmount, err := cliCtx.ParseCoins(req.InitialDeposit.String())
+		initDepositAmount, err := cliCtx.ParseCoins(req.InitialDeposit)
 		if err != nil {
 			utils.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
@@ -104,7 +104,7 @@ func depositHandlerFn(cdc *wire.Codec, cliCtx context.CLIContext) http.HandlerFu
 			utils.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
-		depositAmount, err := cliCtx.ParseCoins(req.Amount.String())
+		depositAmount, err := cliCtx.ParseCoins(req.Amount)
 		if err != nil {
 			utils.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return

--- a/client/lcd/lcd.go
+++ b/client/lcd/lcd.go
@@ -31,7 +31,7 @@ func ServeLCDStartCommand(cdc *wire.Codec) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "start",
-		Short: "Start irislcd (irishub light-client daemon), a local REST server with swagger-ui: http://localhost:1317/swagger-ui/",
+		Short: "Start IRISLCD (IRISHUB light-client daemon), a local REST server with swagger-ui: http://localhost:1317/swagger-ui/",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			listenAddr := viper.GetString(flagListenAddr)
 			router := createHandler(cdc)
@@ -54,7 +54,7 @@ func ServeLCDStartCommand(cdc *wire.Codec) *cobra.Command {
 				return err
 			}
 
-			logger.Info("irislcd server started")
+			logger.Info("IRISLCD server started")
 
 			// wait forever and cleanup
 			cmn.TrapSignal(func() {

--- a/client/lcd/lcd.go
+++ b/client/lcd/lcd.go
@@ -79,19 +79,16 @@ func ServeLCDStartCommand(cdc *wire.Codec) *cobra.Command {
 
 func createHandler(cdc *wire.Codec) *mux.Router {
 	r := mux.NewRouter()
-	kb, err := keys.GetKeyBase()
-	if err != nil {
-		panic(err)
-	}
+
 	cliCtx := context.NewCLIContext().WithCodec(cdc).WithLogger(os.Stdout)
 
 	r.HandleFunc("/version", CLIVersionRequestHandler).Methods("GET")
 	r.HandleFunc("/node_version", NodeVersionRequestHandler(cliCtx)).Methods("GET")
 
 	keyshandler.RegisterRoutes(r)
-	bankhandler.RegisterRoutes(cliCtx, r, cdc, kb)
-	slashinghandler.RegisterRoutes(cliCtx, r, cdc, kb)
-	stakehandler.RegisterRoutes(cliCtx, r, cdc, kb)
+	bankhandler.RegisterRoutes(cliCtx, r, cdc)
+	slashinghandler.RegisterRoutes(cliCtx, r, cdc)
+	stakehandler.RegisterRoutes(cliCtx, r, cdc)
 	govhandler.RegisterRoutes(cliCtx, r, cdc)
 	rpchandler.RegisterRoutes(cliCtx, r, cdc)
 	txhandler.RegisterRoutes(cliCtx, r, cdc)

--- a/client/lcd/lcd.go
+++ b/client/lcd/lcd.go
@@ -9,10 +9,9 @@ import (
 	bankhandler "github.com/irisnet/irishub/client/bank/lcd"
 	"github.com/irisnet/irishub/client/context"
 	govhandler "github.com/irisnet/irishub/client/gov/lcd"
-	"github.com/irisnet/irishub/client/keys"
+	keyshandler "github.com/irisnet/irishub/client/keys/lcd"
 	slashinghandler "github.com/irisnet/irishub/client/slashing/lcd"
 	stakehandler "github.com/irisnet/irishub/client/stake/lcd"
-	keyshandler "github.com/irisnet/irishub/client/keys/lcd"
 	rpchandler "github.com/irisnet/irishub/client/tendermint/rpc"
 	txhandler "github.com/irisnet/irishub/client/tendermint/tx"
 	"github.com/rakyll/statik/fs"
@@ -90,6 +89,7 @@ func createHandler(cdc *wire.Codec) *mux.Router {
 	slashinghandler.RegisterRoutes(cliCtx, r, cdc)
 	stakehandler.RegisterRoutes(cliCtx, r, cdc)
 	govhandler.RegisterRoutes(cliCtx, r, cdc)
+	// tendermint apis
 	rpchandler.RegisterRoutes(cliCtx, r, cdc)
 	txhandler.RegisterRoutes(cliCtx, r, cdc)
 	return r

--- a/client/lcd/swaggerui/swagger.json
+++ b/client/lcd/swaggerui/swagger.json
@@ -1,14 +1,14 @@
 {
   "swagger": "2.0",
   "info": {
-    "description": "All irislcd supported APIs will be shown by this swagger-ui page. You can access these APIs through this page.",
+    "description": "All IRISLCD supported APIs will be shown by this swagger-ui page. You can access them on this page.",
     "version": "1.0",
-    "title": "irislcd Swagger-UI",
-    "termsOfService": "http://swagger.io/terms/",
+    "title": "IRISLCD Swagger-UI",
+    "termsOfService": "https://www.irisnet.org",
     "contact": {
-      "name": "API Support",
-      "url": "http://www.swagger.io/support",
-      "email": "support@swagger.io"
+      "name": "边界智能",
+      "url": "https://bianjie.ai/",
+      "email": "service@bianjie.ai"
     },
     "license": {
       "name": "Apache 2.0",

--- a/client/lcd/swaggerui/swagger.json
+++ b/client/lcd/swaggerui/swagger.json
@@ -235,7 +235,7 @@
           {
             "in": "body",
             "name": "sendToken",
-            "description": "The sender field is required only when generate-only is true. Otherwise, just omit it. \ngasPrice = fee/gas, gasPrice should be no less than 2*10^(-8)iris",
+            "description": "The \"sender\" field is required only when generate-only is true. Otherwise, just omit it. \nThe \"amount\" field can specify multiple tokens, for instance: \"10iris,20atom\". \n\"fee\" can specify multi-token as transaction fee, for instance, \"0.1iris,0.1atom\". Currently, only iris token is valid. Other tokens will be ingnored. \ngasPrice = fee/gas, gasPrice should be no less than 2*10^(-8)iris. The suggested gas is 10000",
             "required": true,
             "schema": {
               "$ref": "#/definitions/bank.TransferBody"
@@ -574,7 +574,7 @@
             "type": "boolean"
           },
           {
-            "description": "gasPrice = fee/gas, gasPrice should be no less than 2*10^(-8)iris",
+            "description": "The \"initial_deposit\" field can specify multiple tokens, for instance: \"10iris,20atom\". \n\"fee\" can specify multi-token as transaction fee, for instance, \"0.1iris,0.1atom\". Currently, only iris token is valid. Other tokens will be ingnored. \ngasPrice = fee/gas, gasPrice should be no less than 2*10^(-8)iris. The suggested gas is 200000",
             "name": "postProposalBody",
             "in": "body",
             "required": true,
@@ -721,7 +721,7 @@
             "in": "path"
           },
           {
-            "description": "gasPrice = fee/gas, gasPrice should be no less than 2*10^(-8)iris",
+            "description": "The \"amount\" field can specify multiple tokens, for instance: \"10iris,20atom\". \n\"fee\" can specify multi-token as transaction fee, for instance, \"0.1iris,0.1atom\". Currently, only iris token is valid. Other tokens will be ingnored. \ngasPrice = fee/gas, gasPrice should be no less than 2*10^(-8)iris. The suggested gas is 200000",
             "name": "depositBody",
             "in": "body",
             "required": true,
@@ -799,7 +799,7 @@
             "in": "path"
           },
           {
-            "description": "gasPrice = fee/gas, gasPrice should be no less than 2*10^(-8)iris",
+            "description": "The value of \"option\" field can be \"Yes\", \"No\", \"NoWithVeto\", \"Abstain\". \n\"fee\" can specify multi-token as transaction fee, for instance, \"0.1iris,0.1atom\". Currently, only iris token is valid. Other tokens will be ingnored. \ngasPrice = fee/gas, gasPrice should be no less than 2*10^(-8)iris. The suggested gas is 200000",
             "name": "voteBody",
             "in": "body",
             "required": true,
@@ -1158,7 +1158,7 @@
             "type": "boolean"
           },
           {
-            "description": "gasPrice = fee/gas, gasPrice should be no less than 2*10^(-8)iris",
+            "description": "The \"delegation\" field under \"delegations\" represent the delegation token amount. It should contains only iris token, for instance: \"10iris\" or \"5.5iris\". \n\"fee\" can specify multi-token as transaction fee, for instance, \"0.1iris,0.1atom\". Currently, only iris token is valid. Other tokens will be ingnored. \ngasPrice = fee/gas, gasPrice should be no less than 2*10^(-8)iris. The suggested gas is 200000",
             "name": "EditDelegationsBody",
             "in": "body",
             "required": true,
@@ -1777,7 +1777,7 @@
         "summary": "Unreoke a revoked validator",
         "parameters": [
           {
-            "description": "gasPrice = fee/gas, gasPrice should be no less than 2*10^(-8)iris",
+            "description": "\"fee\" can specify multi-token as transaction fee, for instance, \"0.1iris,0.1atom\". Currently, only iris token is valid. Other tokens will be ingnored. \ngasPrice = fee/gas, gasPrice should be no less than 2*10^(-8)iris. The suggested gas is 200000",
             "name": "UnrevokeBody",
             "in": "body",
             "required": true,
@@ -2514,11 +2514,7 @@
       "type": "object",
       "properties": {
         "amount": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/common.Coin"
-          }
+          "type": "string"
         },
         "sender": {
           "type": "string"
@@ -2621,11 +2617,7 @@
           "type": "string"
         },
         "initial_deposit": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/common.Coin"
-          }
+          "type": "string"
         }
       }
     },
@@ -2639,11 +2631,7 @@
           "type": "string"
         },
         "amount": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/common.Coin"
-          }
+          "type": "string"
         }
       }
     },
@@ -2710,8 +2698,7 @@
           "type": "string"
         },
         "delegation": {
-          "type": "object",
-          "$ref": "#/definitions/common.Coin"
+          "type": "string"
         }
       }
     },
@@ -2869,12 +2856,10 @@
           "type": "string"
         },
         "initial_balance": {
-          "type": "object",
-          "$ref": "#/definitions/common.Coin"
+          "type": "string"
         },
         "balance": {
-          "type": "object",
-          "$ref": "#/definitions/common.Coin"
+          "type": "string"
         },
         "creation_height": {
           "type": "integer"
@@ -2903,12 +2888,10 @@
           "type": "integer"
         },
         "initial_balance": {
-          "type": "object",
-          "$ref": "#/definitions/common.Coin"
+          "type": "string"
         },
         "balance": {
-          "type": "object",
-          "$ref": "#/definitions/common.Coin"
+          "type": "string"
         },
         "shares_src": {
           "type": "string"
@@ -2967,11 +2950,7 @@
           "type": "integer"
         },
         "proposer_reward_pool": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/common.Coin"
-          }
+          "type": "string"
         },
         "commission": {
           "type": "string"

--- a/client/lcd/swaggerui/swagger.json
+++ b/client/lcd/swaggerui/swagger.json
@@ -574,7 +574,7 @@
             "type": "boolean"
           },
           {
-            "description": "The \"initial_deposit\" field can specify multiple tokens, for instance: \"10iris,20atom\". \n\"fee\" can specify multi-token as transaction fee, for instance, \"0.1iris,0.1atom\". Currently, only iris token is valid. Other tokens will be ingnored. \ngasPrice = fee/gas, gasPrice should be no less than 2*10^(-8)iris. The suggested gas is 200000",
+            "description": "The \"initial_deposit\" field can specify multiple tokens, for instance: \"10iris,20atom\". \nThe \"proposal_type\" represent proposal type, and its value can be \"Text\", \"ParameterChange\", \"SoftwareUpgrade\". \n\"fee\" can specify multi-token as transaction fee, for instance, \"0.1iris,0.1atom\". Currently, only iris token is valid. Other tokens will be ingnored. \ngasPrice = fee/gas, gasPrice should be no less than 2*10^(-8)iris. The suggested gas is 200000",
             "name": "postProposalBody",
             "in": "body",
             "required": true,
@@ -644,7 +644,7 @@
           {
             "in": "query",
             "name": "status",
-            "description": "proposal status",
+            "description": "proposal status, supported values: \"DepositPeriod\", \"VotingPeriod\", \"Passed\", \"Rejected\"",
             "required": false,
             "type": "string"
           }

--- a/client/slashing/lcd/rest.go
+++ b/client/slashing/lcd/rest.go
@@ -1,16 +1,15 @@
 package lcd
 
 import (
-	"github.com/cosmos/cosmos-sdk/crypto/keys"
 	"github.com/cosmos/cosmos-sdk/wire"
 	"github.com/gorilla/mux"
 	"github.com/irisnet/irishub/client/context"
 )
 
 // RegisterRoutes registers staking-related REST handlers to a router
-func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router, cdc *wire.Codec, kb keys.Keybase) {
+func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router, cdc *wire.Codec) {
 	r.HandleFunc("/slashing/signing_info/{validator_pub}",
 		signingInfoHandlerFn(cliCtx, "slashing", cdc)).Methods("GET")
 	r.HandleFunc("/slashing/unrevoke",
-		unrevokeRequestHandlerFn(cdc, kb, cliCtx)).Methods("POST")
+		unrevokeRequestHandlerFn(cdc, cliCtx)).Methods("POST")
 }

--- a/client/slashing/lcd/sendtx.go
+++ b/client/slashing/lcd/sendtx.go
@@ -3,7 +3,6 @@ package lcd
 import (
 	"bytes"
 	"fmt"
-	"github.com/cosmos/cosmos-sdk/crypto/keys"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/wire"
 	"github.com/cosmos/cosmos-sdk/x/slashing"
@@ -18,7 +17,7 @@ type UnrevokeBody struct {
 	ValidatorAddr string         `json:"validator_addr"`
 }
 
-func unrevokeRequestHandlerFn(cdc *wire.Codec, kb keys.Keybase, cliCtx context.CLIContext) http.HandlerFunc {
+func unrevokeRequestHandlerFn(cdc *wire.Codec, cliCtx context.CLIContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var m UnrevokeBody
 		err := utils.ReadPostBody(w, r, cdc, &m)

--- a/client/stake/cli/query.go
+++ b/client/stake/cli/query.go
@@ -37,10 +37,7 @@ func GetCmdQueryValidator(storeName string, cdc *wire.Codec) *cobra.Command {
 				return fmt.Errorf("No validator found with address %s", args[0])
 			}
 
-			validator, err := types.UnmarshalValidator(cdc, addr, res)
-			if err != nil {
-				return err
-			}
+			validator := types.MustUnmarshalValidator(cdc, addr, res)
 			validatorOutput,err := stakeClient.ConvertValidatorToValidatorOutput(cliCtx, validator)
 			if err != nil {
 				return err
@@ -90,10 +87,7 @@ func GetCmdQueryValidators(storeName string, cdc *wire.Codec) *cobra.Command {
 			var validators []stakeClient.ValidatorOutput
 			for _, kv := range resKVs {
 				addr := kv.Key[1:]
-				validator, err := types.UnmarshalValidator(cdc, addr, kv.Value)
-				if err != nil {
-					return err
-				}
+				validator := types.MustUnmarshalValidator(cdc, addr, kv.Value)
 				validatorOutput, err := stakeClient.ConvertValidatorToValidatorOutput(cliCtx, validator)
 				if err != nil {
 					return err
@@ -154,10 +148,7 @@ func GetCmdQueryDelegation(storeName string, cdc *wire.Codec) *cobra.Command {
 			}
 
 			// parse out the delegation
-			delegation, err := types.UnmarshalDelegation(cdc, key, res)
-			if err != nil {
-				return err
-			}
+			delegation := types.MustUnmarshalDelegation(cdc, key, res)
 			delegationOutput := stakeClient.ConvertDelegationToDelegationOutput(cliCtx, delegation)
 			switch viper.Get(cli.OutputFlag) {
 			case "text":
@@ -211,10 +202,7 @@ func GetCmdQueryDelegations(storeName string, cdc *wire.Codec) *cobra.Command {
 			// parse out the validators
 			var delegations []stakeClient.DelegationOutput
 			for _, kv := range resKVs {
-				delegation, err := types.UnmarshalDelegation(cdc, kv.Key, kv.Value)
-				if err != nil {
-					return err
-				}
+				delegation := types.MustUnmarshalDelegation(cdc, kv.Key, kv.Value)
 				delegationOutput := stakeClient.ConvertDelegationToDelegationOutput(cliCtx, delegation)
 				delegations = append(delegations, delegationOutput)
 			}
@@ -260,10 +248,7 @@ func GetCmdQueryUnbondingDelegation(storeName string, cdc *wire.Codec) *cobra.Co
 			}
 
 			// parse out the unbonding delegation
-			ubd, err := types.UnmarshalUBD(cdc, key, res)
-			if err != nil {
-				return err
-			}
+			ubd := types.MustUnmarshalUBD(cdc, key, res)
 			ubdOutput := stakeClient.ConvertUBDToUBDOutput(cliCtx, ubd)
 
 			switch viper.Get(cli.OutputFlag) {
@@ -318,10 +303,7 @@ func GetCmdQueryUnbondingDelegations(storeName string, cdc *wire.Codec) *cobra.C
 			// parse out the validators
 			var ubds []stakeClient.UnbondingDelegationOutput
 			for _, kv := range resKVs {
-				ubd, err := types.UnmarshalUBD(cdc, kv.Key, kv.Value)
-				if err != nil {
-					return err
-				}
+				ubd := types.MustUnmarshalUBD(cdc, kv.Key, kv.Value)
 				ubdOutput := stakeClient.ConvertUBDToUBDOutput(cliCtx, ubd)
 				ubds = append(ubds, ubdOutput)
 			}
@@ -372,10 +354,7 @@ func GetCmdQueryRedelegation(storeName string, cdc *wire.Codec) *cobra.Command {
 			}
 
 			// parse out the unbonding delegation
-			red, err := types.UnmarshalRED(cdc, key, res)
-			if err != nil {
-				return err
-			}
+			red := types.MustUnmarshalRED(cdc, key, res)
 			redOutput := stakeClient.ConvertREDToREDOutput(cliCtx, red)
 			switch viper.Get(cli.OutputFlag) {
 			case "text":
@@ -429,10 +408,7 @@ func GetCmdQueryRedelegations(storeName string, cdc *wire.Codec) *cobra.Command 
 			// parse out the validators
 			var reds []stakeClient.RedelegationOutput
 			for _, kv := range resKVs {
-				red, err := types.UnmarshalRED(cdc, kv.Key, kv.Value)
-				if err != nil {
-					return err
-				}
+				red := types.MustUnmarshalRED(cdc, kv.Key, kv.Value)
 				redOutput := stakeClient.ConvertREDToREDOutput(cliCtx, red)
 				reds = append(reds, redOutput)
 			}

--- a/client/stake/cli/sendtx.go
+++ b/client/stake/cli/sendtx.go
@@ -10,12 +10,13 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/stake"
 	"github.com/cosmos/cosmos-sdk/x/stake/types"
 
+	"github.com/irisnet/irishub/client"
+	"github.com/irisnet/irishub/client/context"
+	stakeClient "github.com/irisnet/irishub/client/stake"
+	"github.com/irisnet/irishub/client/utils"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/irisnet/irishub/client/context"
-	"github.com/irisnet/irishub/client/utils"
-	"github.com/irisnet/irishub/client"
 )
 
 // GetCmdCreateValidator implements the create validator command handler.
@@ -214,7 +215,7 @@ func GetCmdBeginRedelegate(storeName string, cdc *wire.Codec) *cobra.Command {
 			sharesAmountStr := viper.GetString(FlagSharesAmount)
 			sharesPercentStr := viper.GetString(FlagSharesPercent)
 			sharesAmount, err := getShares(
-				storeName, cdc, sharesAmountStr, sharesPercentStr,
+				storeName, cliCtx, cdc, sharesAmountStr, sharesPercentStr,
 				delegatorAddr, validatorSrcAddr,
 			)
 			if err != nil {
@@ -236,7 +237,7 @@ func GetCmdBeginRedelegate(storeName string, cdc *wire.Codec) *cobra.Command {
 // nolint: gocyclo
 // TODO: Make this pass gocyclo linting
 func getShares(
-	storeName string, cdc *wire.Codec, sharesAmountStr,
+	storeName string, cliCtx context.CLIContext, cdc *wire.Codec, sharesAmountStr,
 	sharesPercentStr string, delegatorAddr, validatorAddr sdk.AccAddress,
 ) (sharesAmount sdk.Rat, err error) {
 	switch {
@@ -252,6 +253,7 @@ func getShares(
 		if !sharesAmount.GT(sdk.ZeroRat()) {
 			return sharesAmount, errors.Errorf("shares amount must be positive number (ex. 123, 1.23456789)")
 		}
+		sharesAmount.Quo(stakeClient.ExRateFromStakeTokenToMainUnit(cliCtx))
 	case sharesPercentStr != "":
 		var sharesPercent sdk.Rat
 		sharesPercent, err = sdk.NewRatFromDecimal(sharesPercentStr, types.MaxBondDenominatorPrecision)
@@ -362,7 +364,7 @@ func GetCmdBeginUnbonding(storeName string, cdc *wire.Codec) *cobra.Command {
 			sharesAmountStr := viper.GetString(FlagSharesAmount)
 			sharesPercentStr := viper.GetString(FlagSharesPercent)
 			sharesAmount, err := getShares(
-				storeName, cdc, sharesAmountStr, sharesPercentStr,
+				storeName, cliCtx, cdc, sharesAmountStr, sharesPercentStr,
 				delegatorAddr, validatorAddr,
 			)
 			if err != nil {

--- a/client/stake/common.go
+++ b/client/stake/common.go
@@ -1,0 +1,214 @@
+package stake
+
+import (
+	"fmt"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/stake"
+	"github.com/irisnet/irishub/app"
+	"github.com/irisnet/irishub/client/context"
+	"time"
+)
+
+// defines a delegation without type Rat for shares
+type DelegationOutput struct {
+	DelegatorAddr sdk.AccAddress `json:"delegator_addr"`
+	ValidatorAddr sdk.AccAddress `json:"validator_addr"`
+	Shares        string         `json:"shares"`
+	Height        int64          `json:"height"`
+}
+
+func (d DelegationOutput) HumanReadableString() (string, error) {
+	resp := "Delegation \n"
+	resp += fmt.Sprintf("Delegator: %s\n", d.DelegatorAddr)
+	resp += fmt.Sprintf("Validator: %s\n", d.ValidatorAddr)
+	resp += fmt.Sprintf("Shares: %s", d.Shares)
+	resp += fmt.Sprintf("Height: %d", d.Height)
+
+	return resp, nil
+}
+
+// UnbondingDelegation reflects a delegation's passive unbonding queue.
+type UnbondingDelegationOutput struct {
+	DelegatorAddr  sdk.AccAddress `json:"delegator_addr"`  // delegator
+	ValidatorAddr  sdk.AccAddress `json:"validator_addr"`  // validator unbonding from owner addr
+	CreationHeight int64          `json:"creation_height"` // height which the unbonding took place
+	MinTime        time.Time      `json:"min_time"`        // unix time for unbonding completion
+	InitialBalance string         `json:"initial_balance"` // atoms initially scheduled to receive at completion
+	Balance        string         `json:"balance"`         // atoms to receive at completion
+}
+
+func (d UnbondingDelegationOutput) HumanReadableString() (string, error) {
+	resp := "Unbonding Delegation \n"
+	resp += fmt.Sprintf("Delegator: %s\n", d.DelegatorAddr)
+	resp += fmt.Sprintf("Validator: %s\n", d.ValidatorAddr)
+	resp += fmt.Sprintf("Creation height: %v\n", d.CreationHeight)
+	resp += fmt.Sprintf("Min time to unbond (unix): %v\n", d.MinTime)
+	resp += fmt.Sprintf("Expected balance: %s", d.Balance)
+
+	return resp, nil
+
+}
+
+type RedelegationOutput struct {
+	DelegatorAddr    sdk.AccAddress `json:"delegator_addr"`     // delegator
+	ValidatorSrcAddr sdk.AccAddress `json:"validator_src_addr"` // validator redelegation source owner addr
+	ValidatorDstAddr sdk.AccAddress `json:"validator_dst_addr"` // validator redelegation destination owner addr
+	CreationHeight   int64          `json:"creation_height"`    // height which the redelegation took place
+	MinTime          time.Time      `json:"min_time"`           // unix time for redelegation completion
+	InitialBalance   string         `json:"initial_balance"`    // initial balance when redelegation started
+	Balance          string         `json:"balance"`            // current balance
+	SharesSrc        sdk.Rat        `json:"shares_src"`         // amount of source shares redelegating
+	SharesDst        sdk.Rat        `json:"shares_dst"`         // amount of destination shares redelegating
+}
+
+func (d RedelegationOutput) HumanReadableString() (string, error) {
+	resp := "Redelegation \n"
+	resp += fmt.Sprintf("Delegator: %s\n", d.DelegatorAddr)
+	resp += fmt.Sprintf("Source Validator: %s\n", d.ValidatorSrcAddr)
+	resp += fmt.Sprintf("Destination Validator: %s\n", d.ValidatorDstAddr)
+	resp += fmt.Sprintf("Creation height: %v\n", d.CreationHeight)
+	resp += fmt.Sprintf("Min time to unbond (unix): %v\n", d.MinTime)
+	resp += fmt.Sprintf("Source shares: %s", d.SharesSrc.String())
+	resp += fmt.Sprintf("Destination shares: %s", d.SharesDst.String())
+
+	return resp, nil
+
+}
+
+type ValidatorOutput struct {
+	Owner   sdk.AccAddress `json:"owner"`   // in bech32
+	PubKey  string         `json:"pub_key"` // in bech32
+	Revoked bool           `json:"revoked"` // has the validator been revoked from bonded status?
+
+	Status          sdk.BondStatus `json:"status"`           // validator status (bonded/unbonding/unbonded)
+	Tokens          sdk.Rat        `json:"tokens"`           // delegated tokens (incl. self-delegation)
+	DelegatorShares sdk.Rat        `json:"delegator_shares"` // total shares issued to a validator's delegators
+
+	Description        stake.Description `json:"description"`           // description terms for the validator
+	BondHeight         int64       `json:"bond_height"`           // earliest height as a bonded validator
+	BondIntraTxCounter int16       `json:"bond_intra_tx_counter"` // block-local tx index of validator change
+	ProposerRewardPool []string   `json:"proposer_reward_pool"`  // XXX reward pool collected from being the proposer
+
+	Commission            sdk.Rat `json:"commission"`              // XXX the commission rate of fees charged to any delegators
+	CommissionMax         sdk.Rat `json:"commission_max"`          // XXX maximum commission rate which this validator can ever charge
+	CommissionChangeRate  sdk.Rat `json:"commission_change_rate"`  // XXX maximum daily increase of the validator commission
+	CommissionChangeToday sdk.Rat `json:"commission_change_today"` // XXX commission rate change today, reset each day (UTC time)
+
+	// fee related
+	LastBondedTokens sdk.Rat `json:"prev_bonded_shares"` // last bonded token amount
+}
+
+func (v ValidatorOutput) HumanReadableString() (string, error) {
+	resp := "Validator \n"
+	resp += fmt.Sprintf("Owner: %s\n", v.Owner)
+	resp += fmt.Sprintf("Validator: %s\n", v.PubKey)
+	resp += fmt.Sprintf("Revoked: %v\n", v.Revoked)
+	resp += fmt.Sprintf("Status: %s\n", sdk.BondStatusToString(v.Status))
+	resp += fmt.Sprintf("Tokens: %s\n", v.Tokens.FloatString())
+	resp += fmt.Sprintf("Delegator Shares: %s\n", v.DelegatorShares.FloatString())
+	resp += fmt.Sprintf("Description: %s\n", v.Description)
+	resp += fmt.Sprintf("Bond Height: %d\n", v.BondHeight)
+	resp += fmt.Sprintf("Proposer Reward Pool: %s\n", v.ProposerRewardPool)
+	resp += fmt.Sprintf("Commission: %s\n", v.Commission.String())
+	resp += fmt.Sprintf("Max Commission Rate: %s\n", v.CommissionMax.String())
+	resp += fmt.Sprintf("Commission Change Rate: %s\n", v.CommissionChangeRate.String())
+	resp += fmt.Sprintf("Commission Change Today: %s\n", v.CommissionChangeToday.String())
+	resp += fmt.Sprintf("Previous Bonded Tokens: %s\n", v.LastBondedTokens.String())
+
+	return resp, nil
+}
+
+func ExRateFromStakeTokenToMainUnit(cliCtx context.CLIContext) sdk.Rat {
+	stakeTokenDenom, err := cliCtx.GetCoinType(app.Denom)
+	if err != nil {
+		panic(err)
+	}
+	decimalDiff := stakeTokenDenom.MinUnit.Decimal - stakeTokenDenom.GetMainUnit().Decimal
+	exRate := sdk.NewRat(1).Quo(sdk.NewRatFromInt(sdk.NewIntWithDecimal(1, decimalDiff)))
+	return exRate
+}
+
+func ConvertValidatorToValidatorOutput(cliCtx context.CLIContext, v stake.Validator) (ValidatorOutput, error) {
+	exRate := ExRateFromStakeTokenToMainUnit(cliCtx)
+	poolToken, err := cliCtx.ConvertCoinToMainUnit(v.ProposerRewardPool.String())
+	if err != nil {
+		return ValidatorOutput{}, err
+	}
+	bechValPubkey, err := sdk.Bech32ifyValPub(v.PubKey)
+	if err != nil {
+		return ValidatorOutput{}, err
+	}
+	return ValidatorOutput{
+		Owner:   v.Owner,
+		PubKey:  bechValPubkey,
+		Revoked: v.Revoked,
+
+		Status:          v.Status,
+		Tokens:          v.Tokens.Mul(exRate),
+		DelegatorShares: v.DelegatorShares.Mul(exRate),
+
+		Description:        v.Description,
+		BondHeight:         v.BondHeight,
+		BondIntraTxCounter: v.BondIntraTxCounter,
+		ProposerRewardPool: poolToken,
+
+		Commission:            v.Commission,
+		CommissionMax:         v.CommissionMax,
+		CommissionChangeRate:  v.CommissionChangeRate,
+		CommissionChangeToday: v.CommissionChangeToday,
+
+		LastBondedTokens: v.LastBondedTokens,
+	}, nil
+}
+
+func ConvertDelegationToDelegationOutput(cliCtx context.CLIContext, delegation stake.Delegation) DelegationOutput {
+	exRate := ExRateFromStakeTokenToMainUnit(cliCtx)
+	return DelegationOutput{
+		DelegatorAddr: delegation.DelegatorAddr,
+		ValidatorAddr: delegation.ValidatorAddr,
+		Shares:        delegation.Shares.Mul(exRate).FloatString(),
+		Height:        delegation.Height,
+	}
+}
+
+func ConvertUBDToUBDOutput(cliCtx context.CLIContext, ubd stake.UnbondingDelegation) UnbondingDelegationOutput {
+	initialBalance, err := cliCtx.ConvertCoinToMainUnit(sdk.Coins{ubd.InitialBalance}.String())
+	if err != nil && len(initialBalance) != 1 {
+		panic(err)
+	}
+	balance, err := cliCtx.ConvertCoinToMainUnit(sdk.Coins{ubd.Balance}.String())
+	if err != nil && len(balance) != 1 {
+		panic(err)
+	}
+	return UnbondingDelegationOutput{
+		DelegatorAddr:  ubd.DelegatorAddr,
+		ValidatorAddr:  ubd.ValidatorAddr,
+		CreationHeight: ubd.CreationHeight,
+		MinTime:        ubd.MinTime,
+		InitialBalance: initialBalance[0],
+		Balance:        balance[0],
+	}
+}
+
+func ConvertREDToREDOutput(cliCtx context.CLIContext, red stake.Redelegation) RedelegationOutput {
+	exRate := ExRateFromStakeTokenToMainUnit(cliCtx)
+	initialBalance, err := cliCtx.ConvertCoinToMainUnit(sdk.Coins{red.InitialBalance}.String())
+	if err != nil && len(initialBalance) != 1 {
+		panic(err)
+	}
+	balance, err := cliCtx.ConvertCoinToMainUnit(sdk.Coins{red.Balance}.String())
+	if err != nil && len(balance) != 1 {
+		panic(err)
+	}
+	return RedelegationOutput{
+		DelegatorAddr:    red.DelegatorAddr,
+		ValidatorSrcAddr: red.ValidatorSrcAddr,
+		ValidatorDstAddr: red.ValidatorDstAddr,
+		CreationHeight:   red.CreationHeight,
+		MinTime:          red.MinTime,
+		InitialBalance:   initialBalance[0],
+		Balance:          balance[0],
+		SharesSrc:        red.SharesSrc.Mul(exRate),
+		SharesDst:        red.SharesDst.Mul(exRate),
+	}
+}

--- a/client/stake/lcd/rest.go
+++ b/client/stake/lcd/rest.go
@@ -1,10 +1,10 @@
 package lcd
 
 import (
-	"github.com/cosmos/cosmos-sdk/wire"
-	"github.com/irisnet/irishub/client/context"
-	"github.com/gorilla/mux"
 	"github.com/cosmos/cosmos-sdk/crypto/keys"
+	"github.com/cosmos/cosmos-sdk/wire"
+	"github.com/gorilla/mux"
+	"github.com/irisnet/irishub/client/context"
 )
 
 func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router, cdc *wire.Codec, kb keys.Keybase) {
@@ -27,7 +27,7 @@ func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router, cdc *wire.Codec, k
 
 	// GET /stake/delegators/{delegatorAddr}/validators // Query all validators that a delegator is bonded to
 	r.HandleFunc(
-	"/stake/delegators/{delegatorAddr}/validators",
+		"/stake/delegators/{delegatorAddr}/validators",
 		delegatorValidatorsHandlerFn(cliCtx, cdc),
 	).Methods("GET")
 

--- a/client/stake/lcd/rest.go
+++ b/client/stake/lcd/rest.go
@@ -1,16 +1,15 @@
 package lcd
 
 import (
-	"github.com/cosmos/cosmos-sdk/crypto/keys"
 	"github.com/cosmos/cosmos-sdk/wire"
 	"github.com/gorilla/mux"
 	"github.com/irisnet/irishub/client/context"
 )
 
-func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router, cdc *wire.Codec, kb keys.Keybase) {
+func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router, cdc *wire.Codec) {
 	r.HandleFunc(
 		"/stake/delegators/{delegatorAddr}/delegations",
-		delegationsRequestHandlerFn(cdc, kb, cliCtx),
+		delegationsRequestHandlerFn(cdc, cliCtx),
 	).Methods("POST")
 
 	// GET /stake/delegators/{delegatorAddr} // Get all delegations (delegation, undelegation and redelegation) from a delegator

--- a/client/stake/lcd/sendtx.go
+++ b/client/stake/lcd/sendtx.go
@@ -3,7 +3,6 @@ package lcd
 import (
 	"bytes"
 	"fmt"
-	"github.com/cosmos/cosmos-sdk/crypto/keys"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/wire"
 	"github.com/cosmos/cosmos-sdk/x/stake"
@@ -49,7 +48,7 @@ type EditDelegationsBody struct {
 // nolint: gocyclo
 // TODO: Split this up into several smaller functions, and remove the above nolint
 // TODO: use sdk.ValAddress instead of sdk.AccAddress for validators in messages
-func delegationsRequestHandlerFn(cdc *wire.Codec, kb keys.Keybase, cliCtx context.CLIContext) http.HandlerFunc {
+func delegationsRequestHandlerFn(cdc *wire.Codec, cliCtx context.CLIContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
 		delegatorAddr := vars["delegatorAddr"]

--- a/client/stake/lcd/sendtx.go
+++ b/client/stake/lcd/sendtx.go
@@ -10,13 +10,14 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/stake/types"
 	"github.com/gorilla/mux"
 	"github.com/irisnet/irishub/client/context"
+	stakeClient "github.com/irisnet/irishub/client/stake"
 	"github.com/irisnet/irishub/client/utils"
 	"net/http"
 )
 
 type msgDelegationsInput struct {
 	ValidatorAddr string   `json:"validator_addr"` // in bech32
-	Delegation    sdk.Coin `json:"delegation"`
+	Delegation    string   `json:"delegation"`
 }
 type msgBeginRedelegateInput struct {
 	ValidatorSrcAddr string `json:"validator_src_addr"` // in bech32
@@ -99,7 +100,7 @@ func delegationsRequestHandlerFn(cdc *wire.Codec, kb keys.Keybase, cliCtx contex
 				return
 			}
 
-			delegationToken, err := cliCtx.ParseCoin(msg.Delegation.String())
+			delegationToken, err := cliCtx.ParseCoin(msg.Delegation)
 			if err != nil {
 				utils.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
 				return
@@ -139,7 +140,7 @@ func delegationsRequestHandlerFn(cdc *wire.Codec, kb keys.Keybase, cliCtx contex
 				DelegatorAddr:    delegatorAccAddress,
 				ValidatorSrcAddr: validatorSrcAddr,
 				ValidatorDstAddr: validatorDstAddr,
-				SharesAmount:     shares,
+				SharesAmount:     shares.Quo(stakeClient.ExRateFromStakeTokenToMainUnit(cliCtx)),
 			}
 
 			i++
@@ -186,7 +187,7 @@ func delegationsRequestHandlerFn(cdc *wire.Codec, kb keys.Keybase, cliCtx contex
 			messages[i] = stake.MsgBeginUnbonding{
 				DelegatorAddr: delegatorAccAddress,
 				ValidatorAddr: validatorAddr,
-				SharesAmount:  shares,
+				SharesAmount:  shares.Quo(stakeClient.ExRateFromStakeTokenToMainUnit(cliCtx)),
 			}
 
 			i++


### PR DESCRIPTION
Main changes:
* Improve API docs on swagger-ui page.
* Convert all token and share to its main unit in query. For instance, 1000000000000000000iris-atto equals to 1iris
* Convert token and share to mini unit in sendtx.  For instance, 1iris equals to 1000000000000000000iris-atto