### PR TITLE
R4R: Add chain-id value checking for sign command

### DIFF
--- a/client/bank/cli/sign.go
+++ b/client/bank/cli/sign.go
@@ -39,12 +39,14 @@ recommended to set such parameters manually.`,
 	cmd.Flags().Bool(flagAppend, true, "Append the signature to the existing ones. If disabled, old signatures would be overwritten")
 	cmd.Flags().Bool(flagPrintSigs, false, "Print the addresses that must sign the transaction and those who have already signed it, then exit")
 	cmd.Flags().Bool(flagOffline, false, "Offline mode. Do not query local cache.")
-	cmd.MarkFlagRequired(client.FlagChainID)
 	return cmd
 }
 
 func makeSignCmd(cdc *amino.Codec, decoder auth.AccountDecoder) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) (err error) {
+		if len(viper.GetString(client.FlagChainID)) == 0 {
+			return fmt.Errorf("missing chain-id")
+		}
 		stdTx, err := readAndUnmarshalStdTx(cdc, args[0])
 		if err != nil {
 			return


### PR DESCRIPTION
```
cmd.MarkFlagRequired(client.FlagChainID)
```
The above code doesn't make sense. Because flag `client.FlagChainID` is not defined in this field.