### PR TITLE
R4R:  only use the bonded validator for upgrade tally and gov slash

### DIFF
--- a/modules/gov/handler.go
+++ b/modules/gov/handler.go
@@ -287,7 +287,7 @@ func EndBlocker(ctx sdk.Context, keeper Keeper) (resTags sdk.Tags) {
 		for _, valAddr := range keeper.GetValidatorSet(ctx, proposalID) {
 			if _, ok := votingVals[valAddr.String()]; !ok {
 				val := keeper.ds.GetValidatorSet().Validator(ctx, valAddr)
-				if val != nil && val.GetStatus() != sdk.Unbonded {
+				if val != nil && val.GetStatus() == sdk.Bonded {
 					keeper.ds.GetValidatorSet().Slash(ctx,
 						val.GetConsAddr(),
 						ctx.BlockHeight(),

--- a/modules/gov/handler.go
+++ b/modules/gov/handler.go
@@ -287,7 +287,7 @@ func EndBlocker(ctx sdk.Context, keeper Keeper) (resTags sdk.Tags) {
 		for _, valAddr := range keeper.GetValidatorSet(ctx, proposalID) {
 			if _, ok := votingVals[valAddr.String()]; !ok {
 				val := keeper.ds.GetValidatorSet().Validator(ctx, valAddr)
-				if val != nil {
+				if val != nil && val.GetStatus() != sdk.Unbonded {
 					keeper.ds.GetValidatorSet().Slash(ctx,
 						val.GetConsAddr(),
 						ctx.BlockHeight(),

--- a/modules/upgrade/tally.go
+++ b/modules/upgrade/tally.go
@@ -9,13 +9,16 @@ func tally(ctx sdk.Context,versionProtocol uint64, k Keeper) (passes bool) {
 	totalVotingPower := sdk.ZeroDec()
 	switchVotingPower := sdk.ZeroDec()
 
-	for _, validator := range k.sk.GetAllValidators(ctx) {
+	k.sk.IterateBondedValidatorsByPower(ctx, func(index int64, validator sdk.Validator) (stop bool) {
 		totalVotingPower = totalVotingPower.Add(validator.GetPower())
-		valAcc := validator.ConsAddress().String()
+		valAcc := validator.GetConsAddr().String()
 		if ok := k.GetSignal(ctx, versionProtocol, valAcc); ok {
 			switchVotingPower = switchVotingPower.Add(validator.GetPower())
 		}
-	}
+
+		return false
+	})
+
 	// If more than 95% of validator update , do switch
 	if switchVotingPower.Quo(totalVotingPower).GT(GetUpgradeThreshlod(ctx)) {
 		return true

--- a/types/decimal_test.go
+++ b/types/decimal_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/irisnet/irishub/codec"
 	"github.com/stretchr/testify/require"
 )
 
@@ -229,8 +228,6 @@ func TestTruncate(t *testing.T) {
 		require.Equal(t, tc.exp, resPos, "positive tc %d", tcIndex)
 	}
 }
-
-var cdc = codec.New()
 
 func TestDecMarshalJSON(t *testing.T) {
 	decimal := func(i int64) Dec {


### PR DESCRIPTION
closes: https://github.com/irisnet/irishub/issues/979