### PR TITLE
R4R: Don't register struct of protocol

### DIFF
--- a/types/protocol.go
+++ b/types/protocol.go
@@ -13,13 +13,13 @@ var (
 	UpgradeConfigKey     = []byte("upgrade_config")
 	CurrentVersionKey    = []byte("current_version")
 	LastFailedVersionKey = []byte("last_failed_version")
-	cdc                  = makeCodec()
+	cdc                  = codec.New()
 )
 
 type ProtocolDefinition struct {
-	Version 	uint64	`json:"version"`
-	Software	string	`json:"software"`
-	Height		uint64	`json:"height"`
+	Version  uint64 `json:"version"`
+	Software string `json:"software"`
+	Height   uint64 `json:"height"`
 }
 
 type UpgradeConfig struct {
@@ -36,7 +36,7 @@ func NewProtocolDefinition(version uint64, software string, height uint64) Proto
 }
 
 func NewUpgradeConfig(proposalID uint64, protocol ProtocolDefinition) UpgradeConfig {
-	return UpgradeConfig {
+	return UpgradeConfig{
 		proposalID,
 		protocol,
 	}
@@ -45,13 +45,6 @@ func NewUpgradeConfig(proposalID uint64, protocol ProtocolDefinition) UpgradeCon
 type ProtocolKeeper struct {
 	storeKey StoreKey
 	cdc      *codec.Codec
-}
-
-func makeCodec() *codec.Codec {
-	var cdc = codec.New()
-	cdc.RegisterConcrete(&UpgradeConfig{}, "irishub/protocol/UpgradeConfig", nil)
-	cdc.RegisterConcrete(&ProtocolDefinition{}, "irishub/protocol/ProtocolDefinition", nil)
-	return cdc
 }
 
 func NewProtocolKeeper(key StoreKey) ProtocolKeeper {
@@ -98,7 +91,7 @@ func (pk ProtocolKeeper) GetLastFailedVersion(ctx Context) uint64 {
 	store := ctx.KVStore(pk.storeKey)
 	bz := store.Get(LastFailedVersionKey)
 	if bz == nil {
-		return 0	// default value
+		return 0 // default value
 	}
 	var lastFailedVersion uint64
 	pk.cdc.MustUnmarshalBinaryLengthPrefixed(bz, &lastFailedVersion)


### PR DESCRIPTION
`protocol` have its own codec but iriscli don't register these two structures.
I think it's better not to register these structures that don't need to be modified.