### PR TITLE
Add err checking for broadcast tx sync

### DIFF
--- a/client/context/broadcast.go
+++ b/client/context/broadcast.go
@@ -81,6 +81,10 @@ func (cliCtx CLIContext) BroadcastTxSync(tx []byte) (*ctypes.ResultBroadcastTxCo
 
 	res, err := node.BroadcastTxSync(tx)
 
+	if err != nil {
+		return nil, err
+	}
+
 	result := &ctypes.ResultBroadcastTxCommit{
 		Hash: res.Hash,
 		CheckTx: abci.ResponseCheckTx{


### PR DESCRIPTION
fix irislcd panic error:
```
E[9016-01-09|14:49:21.635] Panic in RPC HTTP handler                    module=irislcd err="runtime error: invalid memory address or nil pointer dereference" stack="goroutine 8 [running]:\nruntime/debug.Stack(0xc000831200, 0xdadb60, 0x1a9a320)
	/usr/local/go/src/runtime/debug/stack.go:24 +0xa7\ngithub.com/irisnet/irishub/vendor/github.com/tendermint/tendermint/rpc/lib/server.RecoverAndLogHandler.func1.1(0xc00000cfe0, 0x133a400, 0xc0000700e0, 0xbf05843c65b2d8fa, 0xc6e0f3da, 0x1ab3620, 0xc00019a700)
	/home/lhy/go/src/github.com/irisnet/irishub/vendor/github.com/tendermint/tendermint/rpc/lib/server/http_server.go:133 +0x50c\npanic(0xdadb60, 0x1a9a320)
	/usr/local/go/src/runtime/panic.go:513 +0x1b9\ngithub.com/irisnet/irishub/client/context.CLIContext.BroadcastTxSync(0xc0001230a0, 0x0, 0x1345b20, 0xc00000db40, 0x132f220, 0xc0000be008, 0x0, 0xed89cc, 0x15, 0xec82dc, ...)
	/home/lhy/go/src/github.com/irisnet/irishub/client/context/broadcast.go:87 +0x128\ngithub.com/irisnet/irishub/client/context.CLIContext.broadcastTxSync(0xc0001230a0, 0x0, 0x1345b20, 0xc00000db40, 0x132f220, 0xc0000be008, 0x0, 0xed89cc, 0x15, 0xec82dc, ...)
	/home/lhy/go/src/github.com/irisnet/irishub/client/context/broadcast.go:116 +0x93\ngithub.com/irisnet/irishub/client/context.CLIContext.BroadcastTx(0xc0001230a0, 0x0, 0x1345b20, 0xc00000db40, 0x132f220, 0xc0000be008, 0x0, 0xed89cc, 0x15, 0xec82dc, ...)
	/home/lhy/go/src/github.com/irisnet/irishub/client/context/broadcast.go:37 +0x20e\ngithub.com/irisnet/irishub/client/bank/lcd.BroadcastTxRequestHandlerFn.func1(0x1338480, 0xc00000cfe0, 0xc00019b100)
	/home/lhy/go/src/github.com/irisnet/irishub/client/bank/lcd/sendtx.go:144 +0x4a2\nnet/http.HandlerFunc.ServeHTTP(0xc000b40800, 0x1338480, 0xc00000cfe0, 0xc00019b100)
	/usr/local/go/src/net/http/server.go:1964 +0x44\ngithub.com/irisnet/irishub/vendor/github.com/gorilla/mux.(*Router).ServeHTTP(0xc000123ab0, 0x1338480, 0xc00000cfe0, 0xc00019b100)
	/home/lhy/go/src/github.com/irisnet/irishub/vendor/github.com/gorilla/mux/mux.go:162 +0xf1\ngithub.com/irisnet/irishub/vendor/github.com/tendermint/tendermint/rpc/lib/server.maxBytesHandler.ServeHTTP(0x132e320, 0xc000123ab0, 0xf4240, 0x1338480, 0xc00000cfe0, 0xc00019a700)
	/home/lhy/go/src/github.com/irisnet/irishub/vendor/github.com/tendermint/tendermint/rpc/lib/server/http_server.go:178 +0xcf\ngithub.com/irisnet/irishub/vendor/github.com/tendermint/tendermint/rpc/lib/server.RecoverAndLogHandler.func1(0x1338980, 0xc0000f6700, 0xc00019a700)
	/home/lhy/go/src/github.com/irisnet/irishub/vendor/github.com/tendermint/tendermint/rpc/lib/server/http_server.go:151 +0x25e\nnet/http.HandlerFunc.ServeHTTP(0xc0001c9230, 0x1338980, 0xc0000f6700, 0xc00019a700)
	/usr/local/go/src/net/http/server.go:1964 +0x44\nnet/http.serverHandler.ServeHTTP(0xc000195450, 0x1338980, 0xc0000f6700, 0xc00019a700)
	/usr/local/go/src/net/http/server.go:2741 +0xab\nnet/http.(*conn).serve(0xc000103a40, 0x1339600, 0xc000082900)
	/usr/local/go/src/net/http/server.go:1847 +0x646\ncreated by net/http.(*Server).Serve
	/usr/local/go/src/net/http/server.go:2851 +0x2f5\n"
```