### PR TITLE
R4R: Move distribution tests back to its module but under a sub-folder

### DIFF
--- a/mock/app.go
+++ b/mock/app.go
@@ -57,6 +57,7 @@ type App struct {
 	KeyParams  *sdk.KVStoreKey
 	TkeyParams *sdk.TransientStoreKey
 	KeyUpgrade *sdk.KVStoreKey
+	KeyGuardian *sdk.KVStoreKey
 
 	// TODO: Abstract this out from not needing to be auth specifically
 	AccountKeeper auth.AccountKeeper
@@ -79,12 +80,7 @@ func NewApp() *App {
 	auth.RegisterCodec(cdc)
 	sdk.RegisterCodec(cdc)
 	codec.RegisterCrypto(cdc)
-/*
-	config := sdk.GetConfig()
-	config.SetBech32PrefixForAccount(bech32PrefixAccAddr, bech32PrefixAccPub)
-	config.SetBech32PrefixForValidator(bech32PrefixValAddr, bech32PrefixValPub)
-	config.SetBech32PrefixForConsensusNode(bech32PrefixConsAddr, bech32PrefixConsPub)
-*/
+
 	bApp := bam.NewBaseApp("mock", logger, db, auth.DefaultTxDecoder(cdc), bam.SetPruning("nothing"))
 
 	// Create your application object
@@ -99,6 +95,7 @@ func NewApp() *App {
 		KeyParams:        sdk.NewKVStoreKey("params"),
 		TkeyParams:       sdk.NewTransientStoreKey("transient_params"),
 		KeyUpgrade:       sdk.NewKVStoreKey("upgrade"),
+		KeyGuardian:      sdk.NewKVStoreKey("guardian"),
 		TotalCoinsSupply: sdk.Coins{},
 	}
 
@@ -138,6 +135,7 @@ func (app *App) CompleteSetup(newKeys ...sdk.StoreKey) error {
 	newKeys = append(newKeys, app.KeyFee)
 	newKeys = append(newKeys, app.TkeyParams)
 	newKeys = append(newKeys, app.TkeyStake)
+	newKeys = append(newKeys, app.KeyGuardian)
 
 	for _, key := range newKeys {
 		switch key.(type) {

--- a/modules/distribution/tests/allocation_test.go
+++ b/modules/distribution/tests/allocation_test.go
@@ -1,4 +1,4 @@
-package distr
+package tests
 
 import (
 	"testing"

--- a/modules/distribution/tests/delegation_test.go
+++ b/modules/distribution/tests/delegation_test.go
@@ -1,4 +1,4 @@
-package distr
+package tests
 
 import (
 	"testing"

--- a/modules/distribution/tests/keeper_test.go
+++ b/modules/distribution/tests/keeper_test.go
@@ -1,4 +1,4 @@
-package distr
+package tests
 
 import (
 	"testing"

--- a/modules/distribution/tests/test_common.go
+++ b/modules/distribution/tests/test_common.go
@@ -1,4 +1,4 @@
-package distr
+package tests
 
 import (
 	"testing"

--- a/modules/distribution/tests/validator_test.go
+++ b/modules/distribution/tests/validator_test.go
@@ -1,4 +1,4 @@
-package distr
+package tests
 
 import (
 	"testing"


### PR DESCRIPTION
Earlier the tests were moved to tests/module simply to get rid of circular dependency.  By putting the tests under a subdirectory of the module we can achieve the same purpose, thus the moving back.