### PR TITLE
R4R: Fix cli sidebar and module command list

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -96,6 +96,13 @@ module.exports = {
                             ]
                         },
                         {
+                            title: 'Distribution',
+                            collapsable: false,
+                            children: [
+                                ['distribution/', 'iriscli distribution']
+                            ]
+                        },
+                        {
                             title: 'Gov',
                             collapsable: false,
                             children: [

--- a/docs/cli-client/README.md
+++ b/docs/cli-client/README.md
@@ -46,15 +46,13 @@ All commands which can be used to send transactions have these global flags. The
 Each modules provides a set of command line interfaces. Here we sort these commands by modules.
 
 1. [bank command](./bank/README.md)
+10. [tendermint command](./tendermint/README.md)
 2. [distribution command](./distribution/README.md)
 3. [gov command](./gov/README.md)
 4. [keys command](./keys/README.md)
-5. [lcd command](./lcd/README.md)
-6. [record command](./record/README.md)
 7. [service command](./service/README.md)
 8. [stake command](./stake/README.md)
 9. [status command](./status/README.md)
-10. [tendermint command](./tendermint/README.md)
 11. [upgrade command](./upgrade/README.md)
 
 ## iriscli config command

--- a/docs/cli-client/README.md
+++ b/docs/cli-client/README.md
@@ -41,20 +41,20 @@ All commands which can be used to send transactions have these global flags. The
 | --sequence int   | int    | false    | 0                     | Sequence number to sign the tx |
 | --trust-node     | bool   | false    | true                  | Don't verify proofs for responses | 
 
-## Modules list
+## Module command list
 
 Each modules provides a set of command line interfaces. Here we sort these commands by modules.
 
-1. [bank command](./bank/README.md)
-10. [tendermint command](./tendermint/README.md)
-2. [distribution command](./distribution/README.md)
-3. [gov command](./gov/README.md)
-4. [keys command](./keys/README.md)
-7. [service command](./service/README.md)
-8. [stake command](./stake/README.md)
-9. [status command](./status/README.md)
-11. [upgrade command](./upgrade/README.md)
+1. [status command](./status/README.md)
+2. [tendermint command](./tendermint/README.md)
+3. [keys command](./keys/README.md)
+4. [bank command](./bank/README.md)
+5. [stake command](./stake/README.md)
+6. [distribution command](./distribution/README.md)
+7. [gov command](./gov/README.md)
+8. [upgrade command](./upgrade/README.md)
+9. [service command](./service/README.md)
 
-## iriscli config command
+## Config command
 
 The `iriscli config` command interactively configures some default parameters, such as chain-id, home, fee, and node.

--- a/docs/zh/cli-client/README.md
+++ b/docs/zh/cli-client/README.md
@@ -42,20 +42,18 @@
 
 每个发送交易的命令都包含上表中的flags，同时不同交易的命令还可能会有自己独有的flags。
 
-## 模块列表
+## 模块命令列表
 
-1. [bank command](./bank/README.md)
-2. [distribution command](./distribution/README.md)
-3. [gov command](./gov/README.md)
-4. [keys command](./keys/README.md)
-5. [lcd command](./lcd/README.md)
-6. [record command](./record/README.md)
-7. [service command](./service/README.md)
-8. [stake command](./stake/README.md)
-9. [status command](./status/README.md)
-10. [tendermint command](./tendermint/README.md)
-11. [upgrade command](./upgrade/README.md)
+1. [status command](./status/README.md)
+2. [tendermint command](./tendermint/README.md)
+3. [keys command](./keys/README.md)
+4. [bank command](./bank/README.md)
+5. [stake command](./stake/README.md)
+6. [distribution command](./distribution/README.md)
+7. [gov command](./gov/README.md)
+8. [upgrade command](./upgrade/README.md)
+9. [service command](./service/README.md)
 
-## iriscli config命令
+## 配置命令
 
 iriscli config命令可以交互式地配置一些默认参数，例如chain-id，home，fee 和 node。


### PR DESCRIPTION
* Distribution module missing from the sidebar
* Broken links for record and lcd in cli README