### PR TITLE
R4R: Enhance the query-signals

### DIFF
--- a/client/upgrade/cli/query.go
+++ b/client/upgrade/cli/query.go
@@ -108,7 +108,7 @@ func GetCmdQuerySignals(storeName string, cdc *codec.Codec) *cobra.Command {
 			}
 
 			if len(validatorConsAddrs) == 0 {
-				fmt.Println("No validators have started the new version.")
+				fmt.Println("No validator has started the new version.")
 				return nil
 			}
 
@@ -133,7 +133,7 @@ func GetCmdQuerySignals(storeName string, cdc *codec.Codec) *cobra.Command {
 					}
 				}
 			}
-			fmt.Println("siganalsVotingPower/totalVotingPower = " + signalsVotingPower.Quo(totalVotingPower).String())
+			fmt.Println("signalsVotingPower/totalVotingPower = " + signalsVotingPower.Quo(totalVotingPower).String())
 			return nil
 		},
 	}


### PR DESCRIPTION
```
# if no one starts the new version
iriscli upgrade query-signals
No validators have started the new version.

iriscli upgrade query-signals                                                          
siganalsVotingPower/totalVotingPower = 0.5000000000

# Flag --detail can show who started the new version
iriscli upgrade query-signals --detail                                                 
fva15cv33a67cfey5eze7238hck6yngw3694ak2elm   100.0000000000
siganalsVotingPower/totalVotingPower = 0.5000000000
```