### PR TITLE
Patch Tendermint dependency to include remote signer patch

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -453,7 +453,7 @@
   version = "v0.12.0-iris"
 
 [[projects]]
-  digest = "1:d75069146141c30fa3de3055c8dbcf71cf68295019d4dca22a74794c7d55a64d"
+  digest = "1:e4ed205ab0767f7dedf7d36e6a4662570c51f85008084ba08ec1ac6b0fc943a9"
   name = "github.com/tendermint/tendermint"
   packages = [
     "abci/client",
@@ -518,9 +518,8 @@
     "version",
   ]
   pruneopts = "UT"
-  revision = "95d1adbd406e7a61e6f4161a62a517a9380224d8"
-  source = "https://github.com/irisnet/tendermint.git"
-  version = "v0.27.3-iris6"
+  revision = "1d89d5d5cb68e188bfe36ff4fdb88d208411110c"
+  source = "https://github.com/cryptiumlabs/tendermint-iris.git"
 
 [[projects]]
   digest = "1:bf6d9a827ea3cad964c2f863302e4f6823170d0b5ed16f72cf1184a7c615067e"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,8 +31,8 @@
 
 [[override]]
   name = "github.com/tendermint/tendermint"
-  source = "https://github.com/irisnet/tendermint.git"
-  version = "=v0.27.3-iris6"
+  source = "https://github.com/cryptiumlabs/tendermint-iris.git"
+  revision = "1d89d5d5cb68e188bfe36ff4fdb88d208411110c"
 
 [[constraint]]
   name = "github.com/emicklei/proto"


### PR DESCRIPTION
I wasn't sure which branch to PR this to. I created the `patch_tendermint` branch from the `v0.12.1` tag (`931d4d866449898a7159a03eab84fb217ab9a647`). 

I think the easiest way would be to get the `chengwenxi/release0.12` branch up to date with the latest changes in `v0.12.1` and then merge this PR into that branch and cut a new release.

This PR only updates the underlying Tendermint instance that is used. Once this PR (https://github.com/irisnet/tendermint/pull/42) is merged the url in `Gopkg.toml` should be updated.

This PR makes Irishub work with a patched version of the KMS (https://github.com/adrianbrink/kms/tree/adrian/iris_integration) and then offers full support for double-sign protection on the Nano Ledger S.

@haifengxi 