### PR TITLE
display correct validator consensus pubkey

### DIFF
--- a/client/stake/utils.go
+++ b/client/stake/utils.go
@@ -137,7 +137,7 @@ func (p PoolOutput) HumanReadableString() string {
 func ConvertValidatorToValidatorOutput(cliCtx context.CLIContext, v stake.Validator) ValidatorOutput {
 	exRate := utils.ExRateFromStakeTokenToMainUnit(cliCtx)
 
-	bechValPubkey, err := sdk.Bech32ifyValPub(v.ConsPubKey)
+	bechConsPubkey, err := sdk.Bech32ifyConsPub(v.ConsPubKey)
 	if err != nil {
 		panic(err)
 	}
@@ -150,7 +150,7 @@ func ConvertValidatorToValidatorOutput(cliCtx context.CLIContext, v stake.Valida
 	}
 	return ValidatorOutput{
 		OperatorAddr:     v.OperatorAddr,
-		ConsPubKey:       bechValPubkey,
+		ConsPubKey:       bechConsPubkey,
 		Jailed:           v.Jailed,
 		Status:           v.Status,
 		Tokens:           utils.ConvertDecToRat(v.Tokens).Mul(exRate).FloatString(),


### PR DESCRIPTION
The value currently display is validator pubkey, not consensus pubkey. E.g the pubkey being displayed here https://testnet.irisplorer.io/#/address/1/fva169x02pq8km0rvum8tgqseexaq7dk5mx5tftt9j is starting with `fvp` not `fcp`.