### PR TITLE
R4R: fix unit test failure and  change prefix for sign-info query

### DIFF
--- a/app/baseapp.go
+++ b/app/baseapp.go
@@ -319,7 +319,7 @@ func (app *BaseApp) InitChain(req abci.RequestInitChain) (res abci.ResponseInitC
 
 	// add block gas meter for any genesis transactions (allow infinite gas)
 	app.deliverState.ctx = app.deliverState.ctx.
-		WithBlockGasMeter(sdk.NewInfiniteGasMeter()).WithCoinFlowTags(sdk.NewCoinFlowRecord(false))
+		WithBlockGasMeter(sdk.NewInfiniteGasMeter())
 
 	res = initChainer(app.deliverState.ctx, app.DeliverTx, req)
 
@@ -603,7 +603,6 @@ func (app *BaseApp) getContextForTx(mode RunTxMode, txBytes []byte) (ctx sdk.Con
 		WithCoinFlowTrigger(txHash)
 	if mode == RunTxModeSimulate {
 		ctx, _ = ctx.CacheContext()
-		ctx = ctx.WithCoinFlowTags(sdk.NewCoinFlowRecord(false))
 	}
 	return
 }

--- a/client/slashing/cli/query.go
+++ b/client/slashing/cli/query.go
@@ -21,7 +21,7 @@ func GetCmdQuerySigningInfo(storeName string, cdc *codec.Codec) *cobra.Command {
 		Example: "iriscli stake signing-info <validator public key>",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			pk, err := sdk.GetValPubKeyBech32(args[0])
+			pk, err := sdk.GetConsPubKeyBech32(args[0])
 			if err != nil {
 				return err
 			}

--- a/client/slashing/lcd/query.go
+++ b/client/slashing/lcd/query.go
@@ -16,7 +16,7 @@ func signingInfoHandlerFn(cliCtx context.CLIContext, storeName string, cdc *code
 	return func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
 
-		pk, err := sdk.GetValPubKeyBech32(vars["validatorPubKey"])
+		pk, err := sdk.GetConsPubKeyBech32(vars["validatorPubKey"])
 		if err != nil {
 			utils.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return

--- a/client/tendermint/rpc/validatorset.go
+++ b/client/tendermint/rpc/validatorset.go
@@ -1,19 +1,18 @@
 package rpc
 
 import (
+	"bytes"
 	"fmt"
+	"net/http"
 	"strconv"
 
-	"github.com/spf13/cobra"
-
-	"bytes"
-	sdk "github.com/irisnet/irishub/types"
 	"github.com/gorilla/mux"
 	"github.com/irisnet/irishub/client"
 	"github.com/irisnet/irishub/client/context"
-	tmtypes "github.com/tendermint/tendermint/types"
-	"net/http"
 	"github.com/irisnet/irishub/client/utils"
+	sdk "github.com/irisnet/irishub/types"
+	"github.com/spf13/cobra"
+	tmtypes "github.com/tendermint/tendermint/types"
 )
 
 // TODO these next two functions feel kinda hacky based on their placement
@@ -21,11 +20,11 @@ import (
 //ValidatorCommand returns the validator set for a given height
 func ValidatorCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "validator-set [height]",
-		Short: "Get the full tendermint validator set at given height",
+		Use:     "validator-set [height]",
+		Short:   "Get the full tendermint validator set at given height",
 		Example: "iriscli tendermint validator-set",
-		Args:  cobra.MaximumNArgs(1),
-		RunE:  printValidators,
+		Args:    cobra.MaximumNArgs(1),
+		RunE:    printValidators,
 	}
 	cmd.Flags().Bool(client.FlagIndentResponse, true, "Add indent to JSON response")
 	cmd.Flags().StringP(client.FlagNode, "n", "tcp://localhost:26657", "Node to connect to")
@@ -36,10 +35,10 @@ func ValidatorCommand() *cobra.Command {
 
 // Validator output in bech32 format
 type ValidatorOutput struct {
-	Address          sdk.ValAddress `json:"address"` // in bech32
-	PubKey           string         `json:"pub_key"` // in bech32
-	ProposerPriority int64          `json:"proposer_priority"`
-	VotingPower      int64          `json:"voting_power"`
+	Address          sdk.ConsAddress `json:"address"` // in bech32
+	PubKey           string          `json:"pub_key"` // in bech32
+	ProposerPriority int64           `json:"proposer_priority"`
+	VotingPower      int64           `json:"voting_power"`
 }
 
 // Validators at a certain height output in bech32 format
@@ -49,13 +48,13 @@ type ResultValidatorsOutput struct {
 }
 
 func bech32ValidatorOutput(validator *tmtypes.Validator) (ValidatorOutput, error) {
-	bechValPubkey, err := sdk.Bech32ifyValPub(validator.PubKey)
+	bechValPubkey, err := sdk.Bech32ifyConsPub(validator.PubKey)
 	if err != nil {
 		return ValidatorOutput{}, err
 	}
 
 	return ValidatorOutput{
-		Address:          sdk.ValAddress(validator.Address),
+		Address:          sdk.ConsAddress(validator.Address),
 		PubKey:           bechValPubkey,
 		ProposerPriority: validator.ProposerPriority,
 		VotingPower:      validator.VotingPower,

--- a/docs/cli-client/stake/unjail.md
+++ b/docs/cli-client/stake/unjail.md
@@ -27,7 +27,7 @@ iriscli stake unjail --from=<key name> --fee=0.12iris --chain-id=<chain-id>
 * Check the jailing time for this validator:
 
 ```$xslt
-iriscli stake signing-info fvp1zcjduepqewwc93xwvt0ym6prxx9ppfzeufs33flkcpu23n5eutjgnnqmgazsw54sfv --node=localhost:36657 --trust-node
+iriscli stake signing-info fcp1zcjduepq8fnuxnceuy4n0fzfc6rvf0spx56waw67lqkrhxwsxgnf8zgk0nus2r55he --node=localhost:36657 --trust-node
 ```
 If your validator is jailed, it will tell the jailing time.
 

--- a/docs/cli-client/stake/validator.md
+++ b/docs/cli-client/stake/validator.md
@@ -26,7 +26,7 @@ After that, you will get the specified validator's info.
 ```txt
 Validator
 Operator Address: fva15grv3xg3ekxh9xrf79zd0w077krgv5xf6d6thd
-Validator Consensus Pubkey: fvp1zcjduepq47906n2zvq597vwyqdc0h35ve0fcl64hwqs9xw5fg67zj4g658aqyuhepj
+Validator Consensus Pubkey: fcp1zcjduepq8fnuxnceuy4n0fzfc6rvf0spx56waw67lqkrhxwsxgnf8zgk0nus2r55he
 Jailed: false
 Status: Bonded
 Tokens: 100.0000000000

--- a/docs/cli-client/stake/validators.md
+++ b/docs/cli-client/stake/validators.md
@@ -26,7 +26,7 @@ After that, you will get all validators' info.
 ```txt
 Validator
 Operator Address: fva15grv3xg3ekxh9xrf79zd0w077krgv5xf6d6thd
-Validator Consensus Pubkey: fvp1zcjduepq47906n2zvq597vwyqdc0h35ve0fcl64hwqs9xw5fg67zj4g658aqyuhepj
+Validator Consensus Pubkey: fcp1zcjduepq8fnuxnceuy4n0fzfc6rvf0spx56waw67lqkrhxwsxgnf8zgk0nus2r55he
 Jailed: false
 Status: Bonded
 Tokens: 100.0000000000

--- a/docs/cli-client/tendermint/validator-set.md
+++ b/docs/cli-client/tendermint/validator-set.md
@@ -41,8 +41,36 @@ or
 ```
 You will get the following result.
 
-```apple js
-{"block_height":"500","validators":[{"address":"fva1znj2x9p7jaww8x0a4ptcse4t68yezytkdjs6my","pub_key":"fvp1zcjduepqwh2pdw3gqstxjye9n2p9gp072e28qyrmpcegu2jg250r7k8y6naqw9epgu","proposer_priority":"-577","voting_power":"4100"},{"address":"fva1rhr9jqskza9und06mfhpdgdlm8q999yuzyhu70","pub_key":"fvp1zcjduepqjmq8r0zrqqpp2d99vlyuld0ga4qfju4uccaxrjwyqv5ykjx0p38sj5xpsm","proposer_priority":"-189","voting_power":"1000"},{"address":"fva19mqr37y2fq57xcpkxq95xrr37yjk7rchsktw73","pub_key":"fvp1zcjduepq5uqrykdrkg7tsr57kk58mjg530jf80zalujgc75y4a6g0uqzk85qra6rnq","proposer_priority":"-77","voting_power":"200"},{"address":"fva127nsk0yxt6843huqwr5sngsse3qdkehd3d0wzz","pub_key":"fvp1zcjduepqf0zsfyzvfreujl996g658tu59l8hy4x73epqnj53r7g7c3lqhazsw6tl5z","proposer_priority":"-1977","voting_power":"100"},{"address":"fva1exfvfnj63vesc5l9xzt6xg9ezfy593zq3m9cyz","pub_key":"fvp1zcjduepq02wagnhd8zcw2x5v68evlpvrthtc5ynkm6rtp8q3e6axw5ns7ylqk0497d","proposer_priority":"2823","voting_power":"300"}]}
+```json
+{
+  "block_height": "113",
+  "validators": [
+    {
+      "address": "fca1q9zpqvm7cadx5walcg5jkdxklayr8c2ucya6mm",
+      "pub_key": "fcp1zcjduepq8fnuxnceuy4n0fzfc6rvf0spx56waw67lqkrhxwsxgnf8zgk0nus2r55he",
+      "proposer_priority": "-300",
+      "voting_power": "100"
+    },
+    {
+      "address": "fca1qxavppd679lyxxu9fdu0zxxfv59r7e0w38mejr",
+      "pub_key": "fcp1zcjduepquvkj9qa9mgyhudkhsqxelr0k4zf45ehw4sv4m5wktzhke4zvskasy6p8nv",
+      "proposer_priority": "100",
+      "voting_power": "100"
+    },
+    {
+      "address": "fca1grd8wp7vezr4czen2nujpejvt6597fmrw0kxhj",
+      "pub_key": "fcp1zcjduepqnudzfngr6aq4hk47w6p9jx5w97fxmwj2vwwvpkd3sez3dzrm359sjpqvmn",
+      "proposer_priority": "100",
+      "voting_power": "100"
+    },
+    {
+      "address": "fca15rg635p4j3xpxcs53dwl6nl2u7gjjsvsx5nesn",
+      "pub_key": "fcp1zcjduepqxhc5c0fyfwta05tax036jmrr2x6aea2smnce9zhmravt7gwpm0qqzwy8vw",
+      "proposer_priority": "100",
+      "voting_power": "100"
+    }
+  ]
+}
 ```
 
 

--- a/docs/features/stake.md
+++ b/docs/features/stake.md
@@ -73,7 +73,7 @@ This specification briefly introduces the functionality of stake module and what
 	```text
     Validator 
     Operator Address: fva1ljemm0yznz58qxxs8xyak7fashcfxf5l9pe40u
-    Validator Consensus Pubkey: fvp1zcjduepq8fw9p4zfrl5fknrdd9tc2l24jnqel6waxlugn66y66dxasmeuzhsxl6m5e
+    Validator Consensus Pubkey: fcp1zcjduepq8fnuxnceuy4n0fzfc6rvf0spx56waw67lqkrhxwsxgnf8zgk0nus2r55he
     Jailed: false
     Status: Bonded
     Tokens: 100.0000000000

--- a/docs/get-started/Validator-Node.md
+++ b/docs/get-started/Validator-Node.md
@@ -55,7 +55,7 @@ iriscli status --node=tcp://localhost:26657
 
 You should also be able to see `catching_up` is `false`. 
 
-You need to get the public key of your node before upgrade your node to a validator node. The public key of your node starts with `fvp`, 
+You need to get the public key of your node before upgrade your node to a validator node. The public key of your node starts with `fcp`, 
 it can be used to create a new validator by staking tokens. To understand more about the address encoding in IRISHub, 
 please read this [doc](../features/basic-concepts/bech32-prefix.md)
 

--- a/docs/zh/cli-client/stake/unjail.md
+++ b/docs/zh/cli-client/stake/unjail.md
@@ -30,7 +30,7 @@ iriscli stake unjail --from=<key name> --fee=0.12iris --chain-id=<chain-id>
 * 检查这个验证人保持`jail`状态的截止时间：
 
 ```$xslt
-iriscli stake signing-info fvp1zcjduepqewwc93xwvt0ym6prxx9ppfzeufs33flkcpu23n5eutjgnnqmgazsw54sfv --node=localhost:36657 --trust-node
+iriscli stake signing-info fcp1zcjduepqewwc93xwvt0ym6prxx9ppfzeufs33flkcpu23n5eutjgnnqmgazsw54sfv --node=localhost:36657 --trust-node
 ```
 
 如果此验证人状态为`jailed`，那么你可以看到它的jail状态的截止时间

--- a/docs/zh/cli-client/stake/validator.md
+++ b/docs/zh/cli-client/stake/validator.md
@@ -26,7 +26,7 @@ iriscli stake validator [validator-address]
 ```txt
 Validator
 Operator Address: fva15grv3xg3ekxh9xrf79zd0w077krgv5xf6d6thd
-Validator Consensus Pubkey: fvp1zcjduepq47906n2zvq597vwyqdc0h35ve0fcl64hwqs9xw5fg67zj4g658aqyuhepj
+Validator Consensus Pubkey: fcp1zcjduepq8fnuxnceuy4n0fzfc6rvf0spx56waw67lqkrhxwsxgnf8zgk0nus2r55he
 Jailed: false
 Status: Bonded
 Tokens: 100.0000000000

--- a/docs/zh/cli-client/stake/validators.md
+++ b/docs/zh/cli-client/stake/validators.md
@@ -26,7 +26,7 @@ iriscli stake validators
 ```txt
 Validator
 Operator Address: fva15grv3xg3ekxh9xrf79zd0w077krgv5xf6d6thd
-Validator Consensus Pubkey: fvp1zcjduepq47906n2zvq597vwyqdc0h35ve0fcl64hwqs9xw5fg67zj4g658aqyuhepj
+Validator Consensus Pubkey: fcp1zcjduepq8fnuxnceuy4n0fzfc6rvf0spx56waw67lqkrhxwsxgnf8zgk0nus2r55he
 Jailed: false
 Status: Bonded
 Tokens: 100.0000000000

--- a/docs/zh/cli-client/tendermint/validator-set.md
+++ b/docs/zh/cli-client/tendermint/validator-set.md
@@ -36,6 +36,34 @@ iriscli tendermint validator-set 114360 --chain-id=irishub-test
 
 示例结果：
 
-```apple js
-{"block_height":"500","validators":[{"address":"fva1znj2x9p7jaww8x0a4ptcse4t68yezytkdjs6my","pub_key":"fvp1zcjduepqwh2pdw3gqstxjye9n2p9gp072e28qyrmpcegu2jg250r7k8y6naqw9epgu","proposer_priority":"-577","voting_power":"4100"},{"address":"fva1rhr9jqskza9und06mfhpdgdlm8q999yuzyhu70","pub_key":"fvp1zcjduepqjmq8r0zrqqpp2d99vlyuld0ga4qfju4uccaxrjwyqv5ykjx0p38sj5xpsm","proposer_priority":"-189","voting_power":"1000"},{"address":"fva19mqr37y2fq57xcpkxq95xrr37yjk7rchsktw73","pub_key":"fvp1zcjduepq5uqrykdrkg7tsr57kk58mjg530jf80zalujgc75y4a6g0uqzk85qra6rnq","proposer_priority":"-77","voting_power":"200"},{"address":"fva127nsk0yxt6843huqwr5sngsse3qdkehd3d0wzz","pub_key":"fvp1zcjduepqf0zsfyzvfreujl996g658tu59l8hy4x73epqnj53r7g7c3lqhazsw6tl5z","proposer_priority":"-1977","voting_power":"100"},{"address":"fva1exfvfnj63vesc5l9xzt6xg9ezfy593zq3m9cyz","pub_key":"fvp1zcjduepq02wagnhd8zcw2x5v68evlpvrthtc5ynkm6rtp8q3e6axw5ns7ylqk0497d","proposer_priority":"2823","voting_power":"300"}]}
+```json
+{
+  "block_height": "113",
+  "validators": [
+    {
+      "address": "fca1q9zpqvm7cadx5walcg5jkdxklayr8c2ucya6mm",
+      "pub_key": "fcp1zcjduepq8fnuxnceuy4n0fzfc6rvf0spx56waw67lqkrhxwsxgnf8zgk0nus2r55he",
+      "proposer_priority": "-300",
+      "voting_power": "100"
+    },
+    {
+      "address": "fca1qxavppd679lyxxu9fdu0zxxfv59r7e0w38mejr",
+      "pub_key": "fcp1zcjduepquvkj9qa9mgyhudkhsqxelr0k4zf45ehw4sv4m5wktzhke4zvskasy6p8nv",
+      "proposer_priority": "100",
+      "voting_power": "100"
+    },
+    {
+      "address": "fca1grd8wp7vezr4czen2nujpejvt6597fmrw0kxhj",
+      "pub_key": "fcp1zcjduepqnudzfngr6aq4hk47w6p9jx5w97fxmwj2vwwvpkd3sez3dzrm359sjpqvmn",
+      "proposer_priority": "100",
+      "voting_power": "100"
+    },
+    {
+      "address": "fca15rg635p4j3xpxcs53dwl6nl2u7gjjsvsx5nesn",
+      "pub_key": "fcp1zcjduepqxhc5c0fyfwta05tax036jmrr2x6aea2smnce9zhmravt7gwpm0qqzwy8vw",
+      "proposer_priority": "100",
+      "voting_power": "100"
+    }
+  ]
+}
 ```

--- a/docs/zh/features/stake.md
+++ b/docs/zh/features/stake.md
@@ -73,7 +73,7 @@
 	```text
     Validator 
     Operator Address: fva1ljemm0yznz58qxxs8xyak7fashcfxf5l9pe40u
-    Validator Consensus Pubkey: fvp1zcjduepq8fw9p4zfrl5fknrdd9tc2l24jnqel6waxlugn66y66dxasmeuzhsxl6m5e
+    Validator Consensus Pubkey: fcp1zcjduepq8fnuxnceuy4n0fzfc6rvf0spx56waw67lqkrhxwsxgnf8zgk0nus2r55he
     Jailed: false
     Status: Bonded
     Tokens: 100.0000000000

--- a/docs/zh/get-started/Validator-Node.md
+++ b/docs/zh/get-started/Validator-Node.md
@@ -54,9 +54,9 @@ iriscli status --node=tcp://localhost:26657
 ```
 若 `catching_up` 字段为 `false`那么你的节点就是同步的。
 
-你需要获取当前节点的公钥信息来执行以下操作，公钥信息以 `fvp`为首字节，想要了解更多的编码信息，请参考以下 [文档](../features/basic-concepts/bech32-prefix.md)
+你需要获取当前节点的公钥信息来执行以下操作，公钥信息以 `fcp`为首字节，想要了解更多的编码信息，请参考以下 [文档](../features/basic-concepts/bech32-prefix.md)
 
-通过执行以下命令获得节点的公钥信息，公钥信息将以`fvp1`开头：
+通过执行以下命令获得节点的公钥信息，公钥信息将以`fcp`开头：
 
 ```
 iris tendermint show-validator --home= {IRIS-HOME}

--- a/types/context.go
+++ b/types/context.go
@@ -51,7 +51,7 @@ func NewContext(ms MultiStore, header abci.Header, isCheckTx bool, logger log.Lo
 	c = c.WithConsensusParams(nil)
 	c = c.WithCheckValidNum(0)
 	c = c.WithCoinFlowTrigger("")
-	c = c.WithCoinFlowTags(nil)
+	c = c.WithCoinFlowTags(NewCoinFlowRecord(false))
 	return c
 }
 


### PR DESCRIPTION
- PR https://github.com/irisnet/irishub/pull/1281 change valiator pubkey prefix, so we have to change sign-info query handler.
- Fix unit test failures for empty CoinFlowTags