### PR TITLE
R4R: Add coin flow record for gov deposit burn

### DIFF
--- a/modules/gov/keeper.go
+++ b/modules/gov/keeper.go
@@ -525,7 +525,9 @@ func (keeper Keeper) RefundDeposits(ctx sdk.Context, proposalID uint64) {
 		}
 	}
 
-	_, err := keeper.ck.BurnCoinsFromAddr(ctx, DepositedCoinsAccAddr, sdk.Coins{sdk.NewCoin(stakeTypes.StakeDenom, DepositSumInt.Sub(RefundSumInt))})
+	burnCoin := sdk.NewCoin(stakeTypes.StakeDenom, DepositSumInt.Sub(RefundSumInt))
+	ctx.CoinFlowTags().AppendCoinFlowTag(ctx, DepositedCoinsAccAddr.String(), "", burnCoin.String(), sdk.GovDepositBurnFlow, "")
+	_, err := keeper.ck.BurnCoinsFromAddr(ctx, DepositedCoinsAccAddr, sdk.Coins{burnCoin})
 	if err != nil {
 		panic(err)
 	}
@@ -542,6 +544,7 @@ func (keeper Keeper) DeleteDeposits(ctx sdk.Context, proposalID uint64) {
 		deposit := &Deposit{}
 		keeper.cdc.MustUnmarshalBinaryLengthPrefixed(depositsIterator.Value(), deposit)
 
+		ctx.CoinFlowTags().AppendCoinFlowTag(ctx, DepositedCoinsAccAddr.String(), "", deposit.Amount.String(), sdk.GovDepositBurnFlow, "")
 		_, err := keeper.ck.BurnCoinsFromAddr(ctx, DepositedCoinsAccAddr, deposit.Amount)
 		if err != nil {
 			panic(err)

--- a/types/contexttags.go
+++ b/types/contexttags.go
@@ -16,6 +16,7 @@ const (
 	BurnFlow                 = "Burn"
 	CommunityTaxUseFlow      = "CommunityTaxUse"
 	GovDepositFlow           = "GovDeposit"
+	GovDepositBurnFlow       = "GovDepositBurn"
 	GovDepositRefundFlow     = "GovDepositRefund"
 	ServiceDepositFlow       = "ServiceDeposit"
 	ServiceDepositRefundFlow = "ServiceDepositRefund"


### PR DESCRIPTION
The missed coin flow record only tracks the gov deposit address. It is a dead address. So rainbow app won't track this address. 