### PR TITLE
Improve error message for insufficient balance

### DIFF
--- a/modules/auth/ante.go
+++ b/modules/auth/ante.go
@@ -248,7 +248,7 @@ func deductFees(acc Account, fee StdFee) (Account, sdk.Result) {
 	}
 	newCoins, ok := coins.SafeMinus(feeAmount)
 	if ok {
-		errMsg := fmt.Sprintf("%s is less than %s", coins, feeAmount)
+		errMsg := fmt.Sprintf("account balance (%s) is less than %s", coins, feeAmount)
 		return nil, sdk.ErrInsufficientFunds(errMsg).Result()
 	}
 	err := acc.SetCoins(newCoins)


### PR DESCRIPTION
This is especially helpful in cases where the account balance is zero (empty). In that case, the error message is " is less than <coins>", which confusing.