### PR TITLE
Revert "Improve error message for insufficient balance"

### DIFF
--- a/modules/auth/ante.go
+++ b/modules/auth/ante.go
@@ -248,7 +248,7 @@ func deductFees(acc Account, fee StdFee) (Account, sdk.Result) {
 	}
 	newCoins, ok := coins.SafeMinus(feeAmount)
 	if ok {
-		errMsg := fmt.Sprintf("account balance (%s) is less than %s", coins, feeAmount)
+		errMsg := fmt.Sprintf("%s is less than %s", coins, feeAmount)
 		return nil, sdk.ErrInsufficientFunds(errMsg).Result()
 	}
 	err := acc.SetCoins(newCoins)


### PR DESCRIPTION
Reverts irisnet/irishub#1329

The block header contains `last_results_hash` which is the hash of all txs deliver result. This PR will change tx deliver result. As a result, the `last_results_hash` of different nodes may be inconsistent. This is not a optional upgrade. So we have to revert this PR.