### PR TITLE
R4R: Revert "Improve result tags for unbond and redelegate"

### DIFF
--- a/modules/stake/keeper/delegation.go
+++ b/modules/stake/keeper/delegation.go
@@ -503,7 +503,6 @@ func (k Keeper) getBeginInfo(ctx sdk.Context, valSrcAddr sdk.ValAddress) (
 		return minTime, height, false
 
 	case validator.Status == sdk.Unbonded:
-		minTime = ctx.BlockHeader().Time
 		return minTime, height, true
 
 	case validator.Status == sdk.Unbonding:


### PR DESCRIPTION
Ref: https://github.com/irisnet/irishub/issues/1383
Reverts: https://github.com/irisnet/irishub/pull/1388

The `minTime` is part of `ResponseDeliverTx.Data`. PR #1388 will make the `last_results_hash` is inconsistent on different nodes. 
This is not an optional upgrade, so revert it.