### PR TITLE
R4R: Reserve iris as keyword for asset symbol name

### DIFF
--- a/app/v1/asset/msgs.go
+++ b/app/v1/asset/msgs.go
@@ -2,9 +2,9 @@ package asset
 
 import (
 	"fmt"
-	"regexp"
-
 	sdk "github.com/irisnet/irishub/types"
+	"regexp"
+	"strings"
 )
 
 const (
@@ -113,6 +113,10 @@ func (msg MsgIssueAsset) ValidateBasic() sdk.Error {
 	symbolLen := len(msg.Symbol)
 	if symbolLen < MinimumAssetSymbolSize || symbolLen > MaximumAssetSymbolSize || !IsBeginWithAlpha(msg.Symbol) || !IsAlphaNumeric(msg.Symbol) {
 		return ErrInvalidAssetSymbol(DefaultCodespace, fmt.Sprintf("invalid asset symbol %s, only accepts alphanumeric characters, and begin with an english letter, length [%d, %d]", msg.Symbol, MinimumAssetSymbolSize, MaximumAssetSymbolSize))
+	}
+
+	if strings.Contains(strings.ToLower(msg.Symbol), sdk.NativeTokenName) {
+		return ErrInvalidAssetSymbol(DefaultCodespace, fmt.Sprintf("invalid asset symbol %s, cat not contain native token symbol %s", msg.Symbol, sdk.NativeTokenName))
 	}
 
 	symbolAtSourceLen := len(msg.SymbolAtSource)


### PR DESCRIPTION
Resolves: #1590 