### PR TITLE
R4R: Reset the prometheus registry when loading a new protocol

### DIFF
--- a/app/baseapp.go
+++ b/app/baseapp.go
@@ -311,12 +311,12 @@ func (app *BaseApp) InitChain(req abci.RequestInitChain) (res abci.ResponseInitC
 	app.setDeliverState(abci.Header{ChainID: req.ChainId})
 	app.setCheckState(abci.Header{ChainID: req.ChainId})
 
-	// load initial protocol with the upgrade info defined in the genesis file
+	// Load the protocol defined in the genesis file, for Class4 upgrade or to test any protocol version.
 	stateJSON := req.AppStateBytes
 	var genesisFileState v0.GenesisFileState
 	v0.MakeCodec().MustUnmarshalJSON(stateJSON, &genesisFileState)
 	initProtocol := genesisFileState.UpgradeData.GenesisVersion.UpgradeInfo.Protocol.Version
-	app.Engine.LoadInitProtocol(initProtocol)
+	app.Engine.LoadProtocol(initProtocol)
 	app.txDecoder = auth.DefaultTxDecoder(app.Engine.GetCurrentProtocol().GetCodec())
 
 	initChainer := app.Engine.GetCurrentProtocol().GetInitChainer()
@@ -329,6 +329,9 @@ func (app *BaseApp) InitChain(req abci.RequestInitChain) (res abci.ResponseInitC
 		WithBlockGasMeter(sdk.NewInfiniteGasMeter())
 
 	res = initChainer(app.deliverState.ctx, app.DeliverTx, req)
+
+	// There may be some application state in the genesis file, so always init the metrics.
+	app.Engine.GetCurrentProtocol().InitMetrics(app.cms)
 
 	// NOTE: we don't commit, but BeginBlock for block 1
 	// starts from this deliverState

--- a/app/baseapp.go
+++ b/app/baseapp.go
@@ -315,9 +315,11 @@ func (app *BaseApp) InitChain(req abci.RequestInitChain) (res abci.ResponseInitC
 	stateJSON := req.AppStateBytes
 	var genesisFileState v0.GenesisFileState
 	v0.MakeCodec().MustUnmarshalJSON(stateJSON, &genesisFileState)
-	initProtocol := genesisFileState.UpgradeData.GenesisVersion.UpgradeInfo.Protocol.Version
-	app.Engine.LoadProtocol(initProtocol)
-	app.txDecoder = auth.DefaultTxDecoder(app.Engine.GetCurrentProtocol().GetCodec())
+	genesisProtocol := genesisFileState.UpgradeData.GenesisVersion.UpgradeInfo.Protocol.Version
+	if genesisProtocol != app.Engine.GetCurrentVersion() {
+		app.Engine.LoadProtocol(genesisProtocol)
+		app.txDecoder = auth.DefaultTxDecoder(app.Engine.GetCurrentProtocol().GetCodec())
+	}
 
 	initChainer := app.Engine.GetCurrentProtocol().GetInitChainer()
 	if initChainer == nil {

--- a/app/protocol/engine.go
+++ b/app/protocol/engine.go
@@ -23,7 +23,7 @@ func NewProtocolEngine(protocolKeeper sdk.ProtocolKeeper) ProtocolEngine {
 	return engine
 }
 
-func (pe *ProtocolEngine) LoadInitProtocol(version uint64) {
+func (pe *ProtocolEngine) LoadProtocol(version uint64) {
 	p, flag := pe.protocols[version]
 	if flag == false {
 		panic("unknown protocol version!!!")

--- a/app/protocol/types.go
+++ b/app/protocol/types.go
@@ -27,5 +27,5 @@ type Protocol interface {
 	Load()
 	Init(ctx sdk.Context)
 	GetCodec() *codec.Codec
-	InitMetrics(store sdk.CommitMultiStore) // init metrics
+	InitMetrics(store sdk.MultiStore) // init metrics
 }

--- a/app/v0/protocol_v0.go
+++ b/app/v0/protocol_v0.go
@@ -19,6 +19,7 @@ import (
 	"github.com/irisnet/irishub/modules/stake"
 	"github.com/irisnet/irishub/modules/upgrade"
 	sdk "github.com/irisnet/irishub/types"
+	"github.com/prometheus/client_golang/prometheus"
 	abci "github.com/tendermint/tendermint/abci/types"
 	cfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/libs/log"
@@ -83,6 +84,7 @@ func NewProtocolV0(version uint64, log log.Logger, pk sdk.ProtocolKeeper, checkI
 
 // Load the configuration of this Protocol
 func (p *ProtocolV0) Load() {
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
 	p.configCodec()
 	p.configKeepers()
 	p.configRouters()

--- a/app/v0/protocol_v0.go
+++ b/app/v0/protocol_v0.go
@@ -94,13 +94,14 @@ func (p *ProtocolV0) Load() {
 
 // Initialize this Protocol, only needed for version > 0
 func (p *ProtocolV0) Init(ctx sdk.Context) {
+	p.InitMetrics(ctx.MultiStore())
 }
 
 func (p *ProtocolV0) GetCodec() *codec.Codec {
 	return p.cdc
 }
 
-func (p *ProtocolV0) InitMetrics(store sdk.CommitMultiStore) {
+func (p *ProtocolV0) InitMetrics(store sdk.MultiStore) {
 	p.StakeKeeper.InitMetrics(store.GetKVStore(protocol.KeyStake))
 	p.serviceKeeper.InitMetrics(store.GetKVStore(protocol.KeyService))
 }

--- a/app/v1/protocol_v1.go
+++ b/app/v1/protocol_v1.go
@@ -20,6 +20,7 @@ import (
 	"github.com/irisnet/irishub/codec"
 	"github.com/irisnet/irishub/modules/guardian"
 	sdk "github.com/irisnet/irishub/types"
+	"github.com/prometheus/client_golang/prometheus"
 	abci "github.com/tendermint/tendermint/abci/types"
 	cfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/libs/log"
@@ -85,6 +86,7 @@ func NewProtocolV1(version uint64, log log.Logger, pk sdk.ProtocolKeeper, checkI
 
 // load the configuration of this Protocol
 func (p *ProtocolV1) Load() {
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
 	p.configCodec()
 	p.configKeepers()
 	p.configRouters()

--- a/app/v1/protocol_v1.go
+++ b/app/v1/protocol_v1.go
@@ -95,6 +95,8 @@ func (p *ProtocolV1) Load() {
 }
 
 func (p *ProtocolV1) Init(ctx sdk.Context) {
+	p.InitMetrics(ctx.MultiStore())
+
 	// initialize asset params
 	p.assetKeeper.Init(ctx)
 
@@ -109,7 +111,7 @@ func (p *ProtocolV1) GetCodec() *codec.Codec {
 	return p.cdc
 }
 
-func (p *ProtocolV1) InitMetrics(store sdk.CommitMultiStore) {
+func (p *ProtocolV1) InitMetrics(store sdk.MultiStore) {
 	p.StakeKeeper.InitMetrics(store.GetKVStore(protocol.KeyStake))
 	p.serviceKeeper.InitMetrics(store.GetKVStore(protocol.KeyService))
 }


### PR DESCRIPTION
The prometheus registry register one metric twice will cause panic.