### PR TITLE
R4R: Fix GetInputAmount formula

### DIFF
--- a/app/v1/coinswap/internal/keeper/swap.go
+++ b/app/v1/coinswap/internal/keeper/swap.go
@@ -40,7 +40,7 @@ func (k Keeper) GetInputAmount(ctx sdk.Context, outputAmt sdk.Int, inputDenom, o
 	outputBalance := reservePool.AmountOf(outputDenom)
 	fee := k.GetFeeParam(ctx)
 
-	numerator := inputBalance.Mul(outputBalance).Mul(fee.Denominator)
+	numerator := inputBalance.Mul(outputAmt).Mul(fee.Denominator)
 	denominator := (outputBalance.Sub(outputAmt)).Mul(fee.Numerator)
 	return numerator.Div(denominator).Add(sdk.OneInt())
 }


### PR DESCRIPTION
Correct formula should be:
```
(1000 * x * ∆y) / (997 * (y - ∆y)) + 1
```
Which the spec describes in section 3.2.2: <https://github.com/runtimeverification/verified-smart-contracts/blob/uniswap/uniswap/x-y-k.pdf>