### PR TITLE
R4R: Decrease gas consumption by logarithm

### DIFF
--- a/app/v1/auth/ante.go
+++ b/app/v1/auth/ante.go
@@ -22,6 +22,7 @@ const (
 	gasPerUnitCost = 1000
 	// max total number of sigs per tx
 	txSigLimit = 7
+	gasLog     = 1.1 // gas logarithm
 )
 
 // NewAnteHandler returns an AnteHandler that checks
@@ -308,7 +309,7 @@ func setGasMeter(simulate bool, ctx sdk.Context, gasLimit uint64) sdk.Context {
 	if simulate || ctx.BlockHeight() == 0 {
 		return ctx.WithGasMeter(sdk.NewInfiniteGasMeter())
 	}
-	return ctx.WithGasMeter(sdk.NewGasMeter(gasLimit))
+	return ctx.WithGasMeter(sdk.NewGasMeterWithLog(gasLimit, gasLog))
 }
 
 func getSignBytesList(chainID string, stdTx StdTx, stdSigs []StdSignature) (signatureBytesList [][]byte) {

--- a/app/v1/auth/ante.go
+++ b/app/v1/auth/ante.go
@@ -14,15 +14,9 @@ import (
 )
 
 const (
-	BlockStoreCostPerByte = 10
-	ed25519VerifyCost     = 59
-	secp256k1VerifyCost   = 100
-	maxMemoCharacters     = 100
-	// how much gas = 1 atom
-	gasPerUnitCost = 1000
-	// max total number of sigs per tx
-	txSigLimit = 7
-	gasLog     = 1.1 // gas logarithm
+	ed25519VerifyCost   = 59
+	secp256k1VerifyCost = 100
+	gasLog              = 1.1 // gas logarithm
 )
 
 // NewAnteHandler returns an AnteHandler that checks

--- a/types/gas_test.go
+++ b/types/gas_test.go
@@ -43,3 +43,28 @@ func TestGasMeter(t *testing.T) {
 
 	}
 }
+
+func TestGasMeterWithLog(t *testing.T) {
+	cases := []struct {
+		limit  Gas
+		usage  Gas
+		log    float64
+		desc   string
+		expect Gas
+	}{
+		{1000, 100, 10, GasWritePerByteDesc, 2},
+		{1000, 100, 10, GasReadPerByteDesc, 2},
+		{1000, 100, 10, "", 100},
+		{1000, 100, 1, GasWritePerByteDesc, 100},
+		{1000, 100, 0, GasWritePerByteDesc, 100},
+		{1000, 100, 0.99, GasWritePerByteDesc, 100},
+		{1000, 100, -0.1, GasWritePerByteDesc, 100},
+	}
+
+	for tcnum, tc := range cases {
+		meter := NewGasMeterWithLog(tc.limit, tc.log)
+
+		meter.ConsumeGas(tc.usage, tc.desc)
+		require.Equal(t, tc.expect, meter.GasConsumed(), "Gas consumption not match. tc #%d", tcnum)
+	}
+}


### PR DESCRIPTION
Resolves: https://github.com/irisnet/irishub/issues/1851

***test result:*** 

|  logarithm | total gas | ReadPerByte | WritePerByte | blockstore | other |
| ---------- | --------- | ------------- | ------------- | ---------- | ------ | 
| - |  6742 | 442 | 3070 | 2790 | 440 | 
| 1.1 | 3732 | 230 | 272 | 2790 | 440 | 
| 1.2 | 3491 | 119 | 142 | 2790 |  440 | 