### PR TITLE
R4R: Do not init total supply for swap coins

### DIFF
--- a/app/v1/auth/keeper.go
+++ b/app/v1/auth/keeper.go
@@ -348,7 +348,7 @@ func (am AccountKeeper) InitTotalSupply(ctx sdk.Context) {
 	tsMap := make(map[string]sdk.Coin)
 	am.IterateAccounts(ctx, func(account Account) (stop bool) {
 		for _, coin := range account.GetCoins() {
-			if sdk.IrisAtto == coin.Denom || sdk.Iris == coin.Denom {
+			if sdk.IrisAtto == coin.Denom || sdk.Iris == coin.Denom || strings.HasPrefix(coin.Denom, sdk.FormatUniABSPrefix) {
 				continue
 			}
 			totalSupply, ok := tsMap[coin.Denom]
@@ -360,7 +360,15 @@ func (am AccountKeeper) InitTotalSupply(ctx sdk.Context) {
 		}
 		return false
 	})
+
+	// Defense against empty token's keyId
+	var coins sdk.Coins
 	for _, coin := range tsMap {
+		coins = append(coins, coin)
+	}
+
+	coins = coins.Sort()
+	for _, coin := range coins {
 		am.SetTotalSupply(ctx, coin)
 	}
 }

--- a/app/v2/coinswap/internal/types/msgs.go
+++ b/app/v2/coinswap/internal/types/msgs.go
@@ -12,7 +12,7 @@ var (
 )
 
 const (
-	FormatUniABSPrefix = "uni:"
+	FormatUniABSPrefix = sdk.FormatUniABSPrefix
 	FormatUniId        = FormatUniABSPrefix + "%s"
 )
 

--- a/types/asset.go
+++ b/types/asset.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 )
 
+const FormatUniABSPrefix = "uni:"
+
 // ConvertIdToTokenKeyId return the store key suffix of a token
 func ConvertIdToTokenKeyId(tokenId string) (key string, err error) {
 	var reToken = `[A-Za-z0-9\.]{3,17}`


### PR DESCRIPTION
Resolves: https://github.com/irisnet/irishub/issues/1960

After traversing all the keys of the `acc` store, I get the diff from two node with different app hashes.
```
totalSupply count: 3
totalSupply::280000000000000000002u-t505854-min
totalSupply:i.t505854:200000000000000000000t505854-min
totalSupply:i.t876757:200000000000000000000t876757-min
```
and
```
totalSupply count: 3
totalSupply::280000000000000000002u-t876757-min
totalSupply:i.t505854:200000000000000000000t505854-min
totalSupply:i.t876757:200000000000000000000t876757-min
```

We store an empty key path for all tokens with the prefix "u-", this is not need.