### PR TITLE
R4R: Bump Tendermint version to irisnet/tendermint v0.31.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.15.4
+
+*Oct 14th, 2019*
+
+### Tendermint
+
+Bump Tendermint version to irisnet/tendermint [v0.31.2](https://github.com/irisnet/tendermint/releases/tag/v0.31.2) to fix the p2p panic error.
+
 ## 0.15.3
 
 *Oct 2th, 2019*

--- a/docs/software/How-to-install-irishub.md
+++ b/docs/software/How-to-install-irishub.md
@@ -2,10 +2,10 @@
 
 ## Latest Version
 
-The Latest version of IRIShub is [v0.15.3](https://github.com/irisnet/irishub/releases/latest)
+The Latest version of IRIShub is [v0.15.4](https://github.com/irisnet/irishub/releases/latest)
 
 ::: tip
-Please replace <latest_iris_version> below with v0.15.3
+Please replace <latest_iris_version> below with v0.15.4
 :::
 
 ## Configure Your Server

--- a/docs/zh/software/How-to-install-irishub.md
+++ b/docs/zh/software/How-to-install-irishub.md
@@ -2,10 +2,10 @@
 
 ## 最新版本
 
-当前IRIShub最新版本为 [v0.15.3](https://github.com/irisnet/irishub/releases/latest)
+当前IRIShub最新版本为 [v0.15.4](https://github.com/irisnet/irishub/releases/latest)
 
 ::: tip
-请将下文中的 <latest_iris_version> 替换为 v0.15.3
+请将下文中的 <latest_iris_version> 替换为 v0.15.4
 :::
 
 ## 服务器配置要求

--- a/go.mod
+++ b/go.mod
@@ -67,6 +67,6 @@ require (
 
 replace (
 	github.com/tendermint/iavl => github.com/irisnet/iavl v0.12.2
-	github.com/tendermint/tendermint => github.com/irisnet/tendermint v0.31.1
+	github.com/tendermint/tendermint => github.com/irisnet/tendermint v0.31.2
 	golang.org/x/crypto => github.com/tendermint/crypto v0.0.0-20180820045704-3764759f34a5
 )

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/irisnet/iavl v0.12.2 h1:M7Y0FwWNRGTq3j+DLbEHAKjTsBaxoovc/A1RaKhdKhY=
 github.com/irisnet/iavl v0.12.2/go.mod h1:JRGfj9mLdUSdoBSpYjo14FRe/qyKv3YKHwHnhuxzKaQ=
-github.com/irisnet/tendermint v0.31.1 h1:RDUdfMVCfya/OJV4FhjlEfvVTXlGSrI0IuKvPf+Chfs=
-github.com/irisnet/tendermint v0.31.1/go.mod h1:cLvoTnSF/1xKjgwfUwqE+frnDCrHCWInffCVfR3eo50=
+github.com/irisnet/tendermint v0.31.2 h1:bpxmRMDx5k7S0xTYuOyagaPnlhw+/Mx5O7q7fQUh3Sc=
+github.com/irisnet/tendermint v0.31.2/go.mod h1:cLvoTnSF/1xKjgwfUwqE+frnDCrHCWInffCVfR3eo50=
 github.com/jmhodges/levigo v0.0.0-20161115193449-c42d9e0ca023 h1:y5P5G9cANJZt3MXlMrgELo5mNLZPXH8aGFFFG7IzPU0=
 github.com/jmhodges/levigo v0.0.0-20161115193449-c42d9e0ca023/go.mod h1:Q6Qx+uH3RAqyK4rFQroq9RL7mdkABMcfhEI+nNuzMJQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 h1:T+h1c/A9Gawja4Y9mFVWj2vyii2bbUNDw3kt9VxK2EY=

--- a/lite/swagger-ui/swagger.yaml
+++ b/lite/swagger-ui/swagger.yaml
@@ -4,7 +4,7 @@ info:
   description: >-
     A REST interface for state queries, transaction generation and
     broadcast.
-  version: "0.15.3"
+  version: "0.15.4"
   title: IRISLCD Swagger-UI
   termsOfService: 'https://www.irisnet.org'
   contact:

--- a/version/version.go
+++ b/version/version.go
@@ -10,7 +10,7 @@ import (
 
 // Version - Iris Version
 const ProtocolVersion = 1
-const Version = "0.15.3"
+const Version = "0.15.4"
 
 // GitCommit set by build flags
 var GitCommit = ""


### PR DESCRIPTION
- Bump Tendermint version to irisnet/tendermint [v0.31.2](https://github.com/irisnet/tendermint/releases/tag/v0.31.2) to fix the p2p panic error.
- Update irishub version to v0.15.4