### PR TITLE
R4R: Panic with string type

### DIFF
--- a/types/coin.go
+++ b/types/coin.go
@@ -138,7 +138,7 @@ func NewCoins(coins ...Coin) Coins {
 	newCoins.Sort()
 
 	if !newCoins.IsValid() {
-		panic(fmt.Errorf("invalid coin set: %s", newCoins))
+		panic(fmt.Sprintf("invalid coin set: %s", newCoins))
 	}
 
 	return newCoins


### PR DESCRIPTION
Resolves: https://github.com/irisnet/irishub/issues/2054

`fmt.Errorf()` returns errors.errorString
```golang
type errorString struct {
	s string
}
```

On panic, using string type has the same effect.