### PR TITLE
R4R: Fix querier error msg

### DIFF
--- a/app/v1/distribution/keeper/querier.go
+++ b/app/v1/distribution/keeper/querier.go
@@ -100,7 +100,7 @@ func queryDelegationDistInfo(ctx sdk.Context, _ []string, req abci.RequestQuery,
 	ddi := k.GetDelegationDistInfo(ctx, params.DelegatorAddress, params.ValidatorAddress)
 	res, errRes := codec.MarshalJSONIndent(k.cdc, ddi)
 	if errRes != nil {
-		return nil, sdk.MarshalResultErr(err)
+		return nil, sdk.MarshalResultErr(errRes)
 	}
 	return res, nil
 }
@@ -125,7 +125,7 @@ func queryAllDelegationDistInfo(ctx sdk.Context, _ []string, req abci.RequestQue
 	k.IterateDelegatorDistInfos(ctx, params.DelegatorAddress, ddiIter)
 	res, errRes := codec.MarshalJSONIndent(k.cdc, distInfos)
 	if errRes != nil {
-		return nil, sdk.MarshalResultErr(err)
+		return nil, sdk.MarshalResultErr(errRes)
 	}
 	return res, nil
 }
@@ -157,7 +157,7 @@ func queryValidatorDistInfo(ctx sdk.Context, _ []string, req abci.RequestQuery, 
 	vdi := k.GetValidatorDistInfo(ctx, params.ValidatorAddress)
 	res, errRes := codec.MarshalJSONIndent(k.cdc, vdi)
 	if errRes != nil {
-		return nil, sdk.MarshalResultErr(err)
+		return nil, sdk.MarshalResultErr(errRes)
 	}
 	return res, nil
 }
@@ -268,7 +268,7 @@ func queryRewards(ctx sdk.Context, _ []string, req abci.RequestQuery, k Keeper) 
 	rewards.Total = rewardTruncate
 	res, errRes := codec.MarshalJSONIndent(k.cdc, rewards)
 	if errRes != nil {
-		return nil, sdk.MarshalResultErr(err)
+		return nil, sdk.MarshalResultErr(errRes)
 	}
 	return res, nil
 }

--- a/app/v1/gov/queryable.go
+++ b/app/v1/gov/queryable.go
@@ -46,10 +46,10 @@ type QueryProposalParams struct {
 }
 
 // nolint: unparam
-func queryProposal(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) (res []byte, err sdk.Error) {
+func queryProposal(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	var params QueryProposalParams
-	err2 := keeper.cdc.UnmarshalJSON(req.Data, &params)
-	if err2 != nil {
+	err := keeper.cdc.UnmarshalJSON(req.Data, &params)
+	if err != nil {
 		return nil, sdk.ParseParamsErr(err)
 	}
 
@@ -58,8 +58,8 @@ func queryProposal(ctx sdk.Context, path []string, req abci.RequestQuery, keeper
 		return nil, ErrUnknownProposal(DefaultCodespace, params.ProposalID)
 	}
 
-	bz, err2 := codec.MarshalJSONIndent(keeper.cdc, proposal)
-	if err2 != nil {
+	bz, err := codec.MarshalJSONIndent(keeper.cdc, proposal)
+	if err != nil {
 		return nil, sdk.MarshalResultErr(err)
 	}
 	return bz, nil
@@ -72,10 +72,10 @@ type QueryDepositParams struct {
 }
 
 // nolint: unparam
-func queryDeposit(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) (res []byte, err sdk.Error) {
+func queryDeposit(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	var params QueryDepositParams
-	err2 := keeper.cdc.UnmarshalJSON(req.Data, &params)
-	if err2 != nil {
+	err := keeper.cdc.UnmarshalJSON(req.Data, &params)
+	if err != nil {
 		return nil, sdk.ParseParamsErr(err)
 	}
 
@@ -93,8 +93,8 @@ func queryDeposit(ctx sdk.Context, path []string, req abci.RequestQuery, keeper 
 		return nil, ErrCodeDepositNotExisted(DefaultCodespace, params.Depositor, params.ProposalID)
 	}
 
-	bz, err2 := codec.MarshalJSONIndent(keeper.cdc, deposit)
-	if err2 != nil {
+	bz, err := codec.MarshalJSONIndent(keeper.cdc, deposit)
+	if err != nil {
 		return nil, sdk.MarshalResultErr(err)
 	}
 	return bz, nil
@@ -107,10 +107,10 @@ type QueryVoteParams struct {
 }
 
 // nolint: unparam
-func queryVote(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) (res []byte, err sdk.Error) {
+func queryVote(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	var params QueryVoteParams
-	err2 := keeper.cdc.UnmarshalJSON(req.Data, &params)
-	if err2 != nil {
+	err := keeper.cdc.UnmarshalJSON(req.Data, &params)
+	if err != nil {
 		return nil, sdk.ParseParamsErr(err)
 	}
 
@@ -124,8 +124,8 @@ func queryVote(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Kee
 		return nil, ErrCodeVoteNotExisted(DefaultCodespace, params.Voter, params.ProposalID)
 	}
 
-	bz, err2 := codec.MarshalJSONIndent(keeper.cdc, vote)
-	if err2 != nil {
+	bz, err := codec.MarshalJSONIndent(keeper.cdc, vote)
+	if err != nil {
 		return nil, sdk.MarshalResultErr(err)
 	}
 	return bz, nil
@@ -137,10 +137,10 @@ type QueryDepositsParams struct {
 }
 
 // nolint: unparam
-func queryDeposits(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) (res []byte, err sdk.Error) {
+func queryDeposits(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	var params QueryDepositsParams
-	err2 := keeper.cdc.UnmarshalJSON(req.Data, &params)
-	if err2 != nil {
+	err := keeper.cdc.UnmarshalJSON(req.Data, &params)
+	if err != nil {
 		return nil, sdk.ParseParamsErr(err)
 	}
 
@@ -162,8 +162,8 @@ func queryDeposits(ctx sdk.Context, path []string, req abci.RequestQuery, keeper
 		deposits = append(deposits, deposit)
 	}
 
-	bz, err2 := codec.MarshalJSONIndent(keeper.cdc, deposits)
-	if err2 != nil {
+	bz, err := codec.MarshalJSONIndent(keeper.cdc, deposits)
+	if err != nil {
 		return nil, sdk.MarshalResultErr(err)
 	}
 	return bz, nil
@@ -175,11 +175,10 @@ type QueryVotesParams struct {
 }
 
 // nolint: unparam
-func queryVotes(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) (res []byte, err sdk.Error) {
+func queryVotes(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	var params QueryVotesParams
-	err2 := keeper.cdc.UnmarshalJSON(req.Data, &params)
-
-	if err2 != nil {
+	err := keeper.cdc.UnmarshalJSON(req.Data, &params)
+	if err != nil {
 		return nil, sdk.ParseParamsErr(err)
 	}
 
@@ -200,8 +199,8 @@ func queryVotes(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Ke
 	if len(votes) == 0 {
 		return nil, nil
 	}
-	bz, err2 := codec.MarshalJSONIndent(keeper.cdc, votes)
-	if err2 != nil {
+	bz, err := codec.MarshalJSONIndent(keeper.cdc, votes)
+	if err != nil {
 		return nil, sdk.MarshalResultErr(err)
 	}
 	return bz, nil
@@ -216,10 +215,10 @@ type QueryProposalsParams struct {
 }
 
 // nolint: unparam
-func queryProposals(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) (res []byte, err sdk.Error) {
+func queryProposals(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	var params QueryProposalsParams
-	err2 := keeper.cdc.UnmarshalJSON(req.Data, &params)
-	if err2 != nil {
+	err := keeper.cdc.UnmarshalJSON(req.Data, &params)
+	if err != nil {
 		return nil, sdk.ParseParamsErr(err)
 	}
 
@@ -229,8 +228,8 @@ func queryProposals(ctx sdk.Context, path []string, req abci.RequestQuery, keepe
 	}
 
 	proposals := keeper.GetProposalsFiltered(ctx, params.Voter, params.Depositor, status, params.Limit)
-	bz, err2 := codec.MarshalJSONIndent(keeper.cdc, proposals)
-	if err2 != nil {
+	bz, err := codec.MarshalJSONIndent(keeper.cdc, proposals)
+	if err != nil {
 		return nil, sdk.MarshalResultErr(err)
 	}
 	return bz, nil
@@ -242,12 +241,12 @@ type QueryTallyParams struct {
 }
 
 // nolint: unparam
-func queryTally(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) (res []byte, err sdk.Error) {
+func queryTally(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	// TODO: Dependant on #1914
 
 	var param QueryTallyParams
-	err2 := keeper.cdc.UnmarshalJSON(req.Data, &param)
-	if err2 != nil {
+	err := keeper.cdc.UnmarshalJSON(req.Data, &param)
+	if err != nil {
 		return nil, sdk.ParseParamsErr(err)
 	}
 
@@ -266,8 +265,8 @@ func queryTally(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Ke
 		_, tallyResult, _ = tally(ctx, keeper, proposal)
 	}
 
-	bz, err2 := codec.MarshalJSONIndent(keeper.cdc, tallyResult)
-	if err2 != nil {
+	bz, err := codec.MarshalJSONIndent(keeper.cdc, tallyResult)
+	if err != nil {
 		return nil, sdk.MarshalResultErr(err)
 	}
 	return bz, nil

--- a/app/v1/stake/querier/queryable.go
+++ b/app/v1/stake/querier/queryable.go
@@ -132,8 +132,8 @@ func queryValidators(ctx sdk.Context, cdc *codec.Codec, req abci.RequestQuery, k
 	validators := k.GetValidators(ctx, params.Page, params.Size)
 
 	res, errRes = codec.MarshalJSONIndent(cdc, validators)
-	if err != nil {
-		return nil, sdk.MarshalResultErr(err)
+	if errRes != nil {
+		return nil, sdk.MarshalResultErr(errRes)
 	}
 	return res, nil
 }
@@ -153,7 +153,7 @@ func queryValidator(ctx sdk.Context, cdc *codec.Codec, req abci.RequestQuery, k 
 
 	res, errRes = codec.MarshalJSONIndent(cdc, validator)
 	if errRes != nil {
-		return nil, sdk.MarshalResultErr(err)
+		return nil, sdk.MarshalResultErr(errRes)
 	}
 	return res, nil
 }
@@ -167,7 +167,7 @@ func queryValidatorDelegations(ctx sdk.Context, cdc *codec.Codec, req abci.Reque
 	delegations := k.GetValidatorDelegations(ctx, params.ValidatorAddr)
 	res, errRes = codec.MarshalJSONIndent(cdc, delegations)
 	if errRes != nil {
-		return nil, sdk.MarshalResultErr(err)
+		return nil, sdk.MarshalResultErr(errRes)
 	}
 	return res, nil
 }
@@ -184,7 +184,7 @@ func queryValidatorUnbondingDelegations(ctx sdk.Context, cdc *codec.Codec, req a
 
 	res, errRes = codec.MarshalJSONIndent(cdc, unbonds)
 	if errRes != nil {
-		return nil, sdk.MarshalResultErr(err)
+		return nil, sdk.MarshalResultErr(errRes)
 	}
 	return res, nil
 }
@@ -201,7 +201,7 @@ func queryValidatorRedelegations(ctx sdk.Context, cdc *codec.Codec, req abci.Req
 
 	res, errRes = codec.MarshalJSONIndent(cdc, redelegations)
 	if errRes != nil {
-		return nil, sdk.MarshalResultErr(err)
+		return nil, sdk.MarshalResultErr(errRes)
 	}
 	return res, nil
 }
@@ -218,7 +218,7 @@ func queryDelegatorDelegations(ctx sdk.Context, cdc *codec.Codec, req abci.Reque
 
 	res, errRes = codec.MarshalJSONIndent(cdc, delegations)
 	if errRes != nil {
-		return nil, sdk.MarshalResultErr(err)
+		return nil, sdk.MarshalResultErr(errRes)
 	}
 	return res, nil
 }
@@ -235,7 +235,7 @@ func queryDelegatorUnbondingDelegations(ctx sdk.Context, cdc *codec.Codec, req a
 
 	res, errRes = codec.MarshalJSONIndent(cdc, unbondingDelegations)
 	if errRes != nil {
-		return nil, sdk.MarshalResultErr(err)
+		return nil, sdk.MarshalResultErr(errRes)
 	}
 	return res, nil
 }
@@ -252,7 +252,7 @@ func queryDelegatorRedelegations(ctx sdk.Context, cdc *codec.Codec, req abci.Req
 
 	res, errRes = codec.MarshalJSONIndent(cdc, redelegations)
 	if errRes != nil {
-		return nil, sdk.MarshalResultErr(err)
+		return nil, sdk.MarshalResultErr(errRes)
 	}
 	return res, nil
 }
@@ -272,7 +272,7 @@ func queryRedelegation(ctx sdk.Context, cdc *codec.Codec, req abci.RequestQuery,
 
 	res, errRes = codec.MarshalJSONIndent(cdc, redelegation)
 	if errRes != nil {
-		return nil, sdk.MarshalResultErr(err)
+		return nil, sdk.MarshalResultErr(errRes)
 	}
 	return res, nil
 }
@@ -291,7 +291,7 @@ func queryDelegatorValidators(ctx sdk.Context, cdc *codec.Codec, req abci.Reques
 
 	res, errRes = codec.MarshalJSONIndent(cdc, validators)
 	if errRes != nil {
-		return nil, sdk.MarshalResultErr(err)
+		return nil, sdk.MarshalResultErr(errRes)
 	}
 	return res, nil
 }
@@ -311,7 +311,7 @@ func queryDelegatorValidator(ctx sdk.Context, cdc *codec.Codec, req abci.Request
 
 	res, errRes = codec.MarshalJSONIndent(cdc, validator)
 	if errRes != nil {
-		return nil, sdk.MarshalResultErr(err)
+		return nil, sdk.MarshalResultErr(errRes)
 	}
 	return res, nil
 }
@@ -331,7 +331,7 @@ func queryDelegation(ctx sdk.Context, cdc *codec.Codec, req abci.RequestQuery, k
 
 	res, errRes = codec.MarshalJSONIndent(cdc, delegation)
 	if errRes != nil {
-		return nil, sdk.MarshalResultErr(err)
+		return nil, sdk.MarshalResultErr(errRes)
 	}
 	return res, nil
 }
@@ -351,7 +351,7 @@ func queryUnbondingDelegation(ctx sdk.Context, cdc *codec.Codec, req abci.Reques
 
 	res, errRes = codec.MarshalJSONIndent(cdc, unbond)
 	if errRes != nil {
-		return nil, sdk.MarshalResultErr(err)
+		return nil, sdk.MarshalResultErr(errRes)
 	}
 	return res, nil
 }
@@ -361,7 +361,7 @@ func queryPool(ctx sdk.Context, cdc *codec.Codec, k keep.Keeper) (res []byte, er
 
 	res, errRes := codec.MarshalJSONIndent(cdc, poolStatus)
 	if errRes != nil {
-		return nil, sdk.MarshalResultErr(err)
+		return nil, sdk.MarshalResultErr(errRes)
 	}
 	return res, nil
 }
@@ -371,7 +371,7 @@ func queryParameters(ctx sdk.Context, cdc *codec.Codec, k keep.Keeper) (res []by
 
 	res, errRes := codec.MarshalJSONIndent(cdc, params)
 	if errRes != nil {
-		return nil, sdk.MarshalResultErr(err)
+		return nil, sdk.MarshalResultErr(errRes)
 	}
 	return res, nil
 }

--- a/app/v3/gov/queryable.go
+++ b/app/v3/gov/queryable.go
@@ -46,10 +46,10 @@ type QueryProposalParams struct {
 }
 
 // nolint: unparam
-func queryProposal(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) (res []byte, err sdk.Error) {
+func queryProposal(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	var params QueryProposalParams
-	err2 := keeper.cdc.UnmarshalJSON(req.Data, &params)
-	if err2 != nil {
+	err := keeper.cdc.UnmarshalJSON(req.Data, &params)
+	if err != nil {
 		return nil, sdk.ParseParamsErr(err)
 	}
 
@@ -58,8 +58,8 @@ func queryProposal(ctx sdk.Context, path []string, req abci.RequestQuery, keeper
 		return nil, ErrUnknownProposal(DefaultCodespace, params.ProposalID)
 	}
 
-	bz, err2 := codec.MarshalJSONIndent(keeper.cdc, proposal)
-	if err2 != nil {
+	bz, err := codec.MarshalJSONIndent(keeper.cdc, proposal)
+	if err != nil {
 		return nil, sdk.MarshalResultErr(err)
 	}
 	return bz, nil
@@ -72,10 +72,10 @@ type QueryDepositParams struct {
 }
 
 // nolint: unparam
-func queryDeposit(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) (res []byte, err sdk.Error) {
+func queryDeposit(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	var params QueryDepositParams
-	err2 := keeper.cdc.UnmarshalJSON(req.Data, &params)
-	if err2 != nil {
+	err := keeper.cdc.UnmarshalJSON(req.Data, &params)
+	if err != nil {
 		return nil, sdk.ParseParamsErr(err)
 	}
 
@@ -93,8 +93,8 @@ func queryDeposit(ctx sdk.Context, path []string, req abci.RequestQuery, keeper 
 		return nil, ErrCodeDepositNotExisted(DefaultCodespace, params.Depositor, params.ProposalID)
 	}
 
-	bz, err2 := codec.MarshalJSONIndent(keeper.cdc, deposit)
-	if err2 != nil {
+	bz, err := codec.MarshalJSONIndent(keeper.cdc, deposit)
+	if err != nil {
 		return nil, sdk.MarshalResultErr(err)
 	}
 	return bz, nil
@@ -107,10 +107,10 @@ type QueryVoteParams struct {
 }
 
 // nolint: unparam
-func queryVote(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) (res []byte, err sdk.Error) {
+func queryVote(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	var params QueryVoteParams
-	err2 := keeper.cdc.UnmarshalJSON(req.Data, &params)
-	if err2 != nil {
+	err := keeper.cdc.UnmarshalJSON(req.Data, &params)
+	if err != nil {
 		return nil, sdk.ParseParamsErr(err)
 	}
 
@@ -124,8 +124,8 @@ func queryVote(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Kee
 		return nil, ErrCodeVoteNotExisted(DefaultCodespace, params.Voter, params.ProposalID)
 	}
 
-	bz, err2 := codec.MarshalJSONIndent(keeper.cdc, vote)
-	if err2 != nil {
+	bz, err := codec.MarshalJSONIndent(keeper.cdc, vote)
+	if err != nil {
 		return nil, sdk.MarshalResultErr(err)
 	}
 	return bz, nil
@@ -137,10 +137,10 @@ type QueryDepositsParams struct {
 }
 
 // nolint: unparam
-func queryDeposits(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) (res []byte, err sdk.Error) {
+func queryDeposits(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	var params QueryDepositsParams
-	err2 := keeper.cdc.UnmarshalJSON(req.Data, &params)
-	if err2 != nil {
+	err := keeper.cdc.UnmarshalJSON(req.Data, &params)
+	if err != nil {
 		return nil, sdk.ParseParamsErr(err)
 	}
 
@@ -162,8 +162,8 @@ func queryDeposits(ctx sdk.Context, path []string, req abci.RequestQuery, keeper
 		deposits = append(deposits, deposit)
 	}
 
-	bz, err2 := codec.MarshalJSONIndent(keeper.cdc, deposits)
-	if err2 != nil {
+	bz, err := codec.MarshalJSONIndent(keeper.cdc, deposits)
+	if err != nil {
 		return nil, sdk.MarshalResultErr(err)
 	}
 	return bz, nil
@@ -175,11 +175,10 @@ type QueryVotesParams struct {
 }
 
 // nolint: unparam
-func queryVotes(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) (res []byte, err sdk.Error) {
+func queryVotes(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	var params QueryVotesParams
-	err2 := keeper.cdc.UnmarshalJSON(req.Data, &params)
-
-	if err2 != nil {
+	err := keeper.cdc.UnmarshalJSON(req.Data, &params)
+	if err != nil {
 		return nil, sdk.ParseParamsErr(err)
 	}
 
@@ -200,8 +199,8 @@ func queryVotes(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Ke
 	if len(votes) == 0 {
 		return nil, nil
 	}
-	bz, err2 := codec.MarshalJSONIndent(keeper.cdc, votes)
-	if err2 != nil {
+	bz, err := codec.MarshalJSONIndent(keeper.cdc, votes)
+	if err != nil {
 		return nil, sdk.MarshalResultErr(err)
 	}
 	return bz, nil
@@ -216,10 +215,10 @@ type QueryProposalsParams struct {
 }
 
 // nolint: unparam
-func queryProposals(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) (res []byte, err sdk.Error) {
+func queryProposals(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	var params QueryProposalsParams
-	err2 := keeper.cdc.UnmarshalJSON(req.Data, &params)
-	if err2 != nil {
+	err := keeper.cdc.UnmarshalJSON(req.Data, &params)
+	if err != nil {
 		return nil, sdk.ParseParamsErr(err)
 	}
 
@@ -229,8 +228,8 @@ func queryProposals(ctx sdk.Context, path []string, req abci.RequestQuery, keepe
 	}
 
 	proposals := keeper.GetProposalsFiltered(ctx, params.Voter, params.Depositor, status, params.Limit)
-	bz, err2 := codec.MarshalJSONIndent(keeper.cdc, proposals)
-	if err2 != nil {
+	bz, err := codec.MarshalJSONIndent(keeper.cdc, proposals)
+	if err != nil {
 		return nil, sdk.MarshalResultErr(err)
 	}
 	return bz, nil
@@ -242,12 +241,12 @@ type QueryTallyParams struct {
 }
 
 // nolint: unparam
-func queryTally(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) (res []byte, err sdk.Error) {
+func queryTally(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	// TODO: Dependant on #1914
 
 	var param QueryTallyParams
-	err2 := keeper.cdc.UnmarshalJSON(req.Data, &param)
-	if err2 != nil {
+	err := keeper.cdc.UnmarshalJSON(req.Data, &param)
+	if err != nil {
 		return nil, sdk.ParseParamsErr(err)
 	}
 
@@ -266,8 +265,8 @@ func queryTally(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Ke
 		_, tallyResult, _ = tally(ctx, keeper, proposal)
 	}
 
-	bz, err2 := codec.MarshalJSONIndent(keeper.cdc, tallyResult)
-	if err2 != nil {
+	bz, err := codec.MarshalJSONIndent(keeper.cdc, tallyResult)
+	if err != nil {
 		return nil, sdk.MarshalResultErr(err)
 	}
 	return bz, nil

--- a/modules/distribution/keeper/querier.go
+++ b/modules/distribution/keeper/querier.go
@@ -104,7 +104,7 @@ func queryDelegationDistInfo(ctx sdk.Context, _ []string, req abci.RequestQuery,
 	ddi := k.GetDelegationDistInfo(ctx, params.DelegatorAddress, params.ValidatorAddress)
 	res, errRes := codec.MarshalJSONIndent(k.cdc, ddi)
 	if errRes != nil {
-		return nil, sdk.MarshalResultErr(err)
+		return nil, sdk.MarshalResultErr(errRes)
 	}
 	return res, nil
 }
@@ -129,7 +129,7 @@ func queryAllDelegationDistInfo(ctx sdk.Context, _ []string, req abci.RequestQue
 	k.IterateDelegatorDistInfos(ctx, params.DelegatorAddress, ddiIter)
 	res, errRes := codec.MarshalJSONIndent(k.cdc, distInfos)
 	if errRes != nil {
-		return nil, sdk.MarshalResultErr(err)
+		return nil, sdk.MarshalResultErr(errRes)
 	}
 	return res, nil
 }
@@ -161,7 +161,7 @@ func queryValidatorDistInfo(ctx sdk.Context, _ []string, req abci.RequestQuery, 
 	vdi := k.GetValidatorDistInfo(ctx, params.ValidatorAddress)
 	res, errRes := codec.MarshalJSONIndent(k.cdc, vdi)
 	if errRes != nil {
-		return nil, sdk.MarshalResultErr(err)
+		return nil, sdk.MarshalResultErr(errRes)
 	}
 	return res, nil
 }
@@ -257,7 +257,7 @@ func queryRewards(ctx sdk.Context, _ []string, req abci.RequestQuery, k Keeper) 
 	rewards.Total = rewardTruncate
 	res, errRes := codec.MarshalJSONIndent(k.cdc, rewards)
 	if errRes != nil {
-		return nil, sdk.MarshalResultErr(err)
+		return nil, sdk.MarshalResultErr(errRes)
 	}
 	return res, nil
 }

--- a/modules/gov/queryable.go
+++ b/modules/gov/queryable.go
@@ -46,10 +46,10 @@ type QueryProposalParams struct {
 }
 
 // nolint: unparam
-func queryProposal(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) (res []byte, err sdk.Error) {
+func queryProposal(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	var params QueryProposalParams
-	err2 := keeper.cdc.UnmarshalJSON(req.Data, &params)
-	if err2 != nil {
+	err := keeper.cdc.UnmarshalJSON(req.Data, &params)
+	if err != nil {
 		return nil, sdk.ParseParamsErr(err)
 	}
 
@@ -58,8 +58,8 @@ func queryProposal(ctx sdk.Context, path []string, req abci.RequestQuery, keeper
 		return nil, ErrUnknownProposal(DefaultCodespace, params.ProposalID)
 	}
 
-	bz, err2 := codec.MarshalJSONIndent(keeper.cdc, proposal)
-	if err2 != nil {
+	bz, err := codec.MarshalJSONIndent(keeper.cdc, proposal)
+	if err != nil {
 		return nil, sdk.MarshalResultErr(err)
 	}
 	return bz, nil
@@ -72,10 +72,10 @@ type QueryDepositParams struct {
 }
 
 // nolint: unparam
-func queryDeposit(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) (res []byte, err sdk.Error) {
+func queryDeposit(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	var params QueryDepositParams
-	err2 := keeper.cdc.UnmarshalJSON(req.Data, &params)
-	if err2 != nil {
+	err := keeper.cdc.UnmarshalJSON(req.Data, &params)
+	if err != nil {
 		return nil, sdk.ParseParamsErr(err)
 	}
 
@@ -93,8 +93,8 @@ func queryDeposit(ctx sdk.Context, path []string, req abci.RequestQuery, keeper 
 		return nil, ErrCodeDepositNotExisted(DefaultCodespace, params.Depositor, params.ProposalID)
 	}
 
-	bz, err2 := codec.MarshalJSONIndent(keeper.cdc, deposit)
-	if err2 != nil {
+	bz, err := codec.MarshalJSONIndent(keeper.cdc, deposit)
+	if err != nil {
 		return nil, sdk.MarshalResultErr(err)
 	}
 	return bz, nil
@@ -107,10 +107,10 @@ type QueryVoteParams struct {
 }
 
 // nolint: unparam
-func queryVote(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) (res []byte, err sdk.Error) {
+func queryVote(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	var params QueryVoteParams
-	err2 := keeper.cdc.UnmarshalJSON(req.Data, &params)
-	if err2 != nil {
+	err := keeper.cdc.UnmarshalJSON(req.Data, &params)
+	if err != nil {
 		return nil, sdk.ParseParamsErr(err)
 	}
 
@@ -124,8 +124,8 @@ func queryVote(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Kee
 		return nil, ErrCodeVoteNotExisted(DefaultCodespace, params.Voter, params.ProposalID)
 	}
 
-	bz, err2 := codec.MarshalJSONIndent(keeper.cdc, vote)
-	if err2 != nil {
+	bz, err := codec.MarshalJSONIndent(keeper.cdc, vote)
+	if err != nil {
 		return nil, sdk.MarshalResultErr(err)
 	}
 	return bz, nil
@@ -137,10 +137,10 @@ type QueryDepositsParams struct {
 }
 
 // nolint: unparam
-func queryDeposits(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) (res []byte, err sdk.Error) {
+func queryDeposits(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	var params QueryDepositsParams
-	err2 := keeper.cdc.UnmarshalJSON(req.Data, &params)
-	if err2 != nil {
+	err := keeper.cdc.UnmarshalJSON(req.Data, &params)
+	if err != nil {
 		return nil, sdk.ParseParamsErr(err)
 	}
 
@@ -162,8 +162,8 @@ func queryDeposits(ctx sdk.Context, path []string, req abci.RequestQuery, keeper
 		deposits = append(deposits, deposit)
 	}
 
-	bz, err2 := codec.MarshalJSONIndent(keeper.cdc, deposits)
-	if err2 != nil {
+	bz, err := codec.MarshalJSONIndent(keeper.cdc, deposits)
+	if err != nil {
 		return nil, sdk.MarshalResultErr(err)
 	}
 	return bz, nil
@@ -175,11 +175,10 @@ type QueryVotesParams struct {
 }
 
 // nolint: unparam
-func queryVotes(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) (res []byte, err sdk.Error) {
+func queryVotes(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	var params QueryVotesParams
-	err2 := keeper.cdc.UnmarshalJSON(req.Data, &params)
-
-	if err2 != nil {
+	err := keeper.cdc.UnmarshalJSON(req.Data, &params)
+	if err != nil {
 		return nil, sdk.ParseParamsErr(err)
 	}
 
@@ -200,8 +199,8 @@ func queryVotes(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Ke
 	if len(votes) == 0 {
 		return nil, nil
 	}
-	bz, err2 := codec.MarshalJSONIndent(keeper.cdc, votes)
-	if err2 != nil {
+	bz, err := codec.MarshalJSONIndent(keeper.cdc, votes)
+	if err != nil {
 		return nil, sdk.MarshalResultErr(err)
 	}
 	return bz, nil
@@ -216,16 +215,16 @@ type QueryProposalsParams struct {
 }
 
 // nolint: unparam
-func queryProposals(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) (res []byte, err sdk.Error) {
+func queryProposals(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	var params QueryProposalsParams
-	err2 := keeper.cdc.UnmarshalJSON(req.Data, &params)
-	if err2 != nil {
+	err := keeper.cdc.UnmarshalJSON(req.Data, &params)
+	if err != nil {
 		return nil, sdk.ParseParamsErr(err)
 	}
 
 	proposals := keeper.GetProposalsFiltered(ctx, params.Voter, params.Depositor, params.ProposalStatus, params.Limit)
-	bz, err2 := codec.MarshalJSONIndent(keeper.cdc, proposals)
-	if err2 != nil {
+	bz, err := codec.MarshalJSONIndent(keeper.cdc, proposals)
+	if err != nil {
 		return nil, sdk.MarshalResultErr(err)
 	}
 	return bz, nil
@@ -237,12 +236,12 @@ type QueryTallyParams struct {
 }
 
 // nolint: unparam
-func queryTally(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) (res []byte, err sdk.Error) {
+func queryTally(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	// TODO: Dependant on #1914
 
 	var param QueryTallyParams
-	err2 := keeper.cdc.UnmarshalJSON(req.Data, &param)
-	if err2 != nil {
+	err := keeper.cdc.UnmarshalJSON(req.Data, &param)
+	if err != nil {
 		return nil, sdk.ParseParamsErr(err)
 	}
 
@@ -261,8 +260,8 @@ func queryTally(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Ke
 		_, tallyResult, _ = tally(ctx, keeper, proposal)
 	}
 
-	bz, err2 := codec.MarshalJSONIndent(keeper.cdc, tallyResult)
-	if err2 != nil {
+	bz, err := codec.MarshalJSONIndent(keeper.cdc, tallyResult)
+	if err != nil {
 		return nil, sdk.MarshalResultErr(err)
 	}
 	return bz, nil

--- a/modules/stake/querier/queryable.go
+++ b/modules/stake/querier/queryable.go
@@ -132,8 +132,8 @@ func queryValidators(ctx sdk.Context, cdc *codec.Codec, req abci.RequestQuery, k
 	validators := k.GetValidators(ctx, params.Page, params.Size)
 
 	res, errRes = codec.MarshalJSONIndent(cdc, validators)
-	if err != nil {
-		return nil, sdk.MarshalResultErr(err)
+	if errRes != nil {
+		return nil, sdk.MarshalResultErr(errRes)
 	}
 	return res, nil
 }
@@ -153,7 +153,7 @@ func queryValidator(ctx sdk.Context, cdc *codec.Codec, req abci.RequestQuery, k 
 
 	res, errRes = codec.MarshalJSONIndent(cdc, validator)
 	if errRes != nil {
-		return nil, sdk.MarshalResultErr(err)
+		return nil, sdk.MarshalResultErr(errRes)
 	}
 	return res, nil
 }
@@ -167,7 +167,7 @@ func queryValidatorDelegations(ctx sdk.Context, cdc *codec.Codec, req abci.Reque
 	delegations := k.GetValidatorDelegations(ctx, params.ValidatorAddr)
 	res, errRes = codec.MarshalJSONIndent(cdc, delegations)
 	if errRes != nil {
-		return nil, sdk.MarshalResultErr(err)
+		return nil, sdk.MarshalResultErr(errRes)
 	}
 	return res, nil
 }
@@ -184,7 +184,7 @@ func queryValidatorUnbondingDelegations(ctx sdk.Context, cdc *codec.Codec, req a
 
 	res, errRes = codec.MarshalJSONIndent(cdc, unbonds)
 	if errRes != nil {
-		return nil, sdk.MarshalResultErr(err)
+		return nil, sdk.MarshalResultErr(errRes)
 	}
 	return res, nil
 }
@@ -201,7 +201,7 @@ func queryValidatorRedelegations(ctx sdk.Context, cdc *codec.Codec, req abci.Req
 
 	res, errRes = codec.MarshalJSONIndent(cdc, redelegations)
 	if errRes != nil {
-		return nil, sdk.MarshalResultErr(err)
+		return nil, sdk.MarshalResultErr(errRes)
 	}
 	return res, nil
 }
@@ -218,7 +218,7 @@ func queryDelegatorDelegations(ctx sdk.Context, cdc *codec.Codec, req abci.Reque
 
 	res, errRes = codec.MarshalJSONIndent(cdc, delegations)
 	if errRes != nil {
-		return nil, sdk.MarshalResultErr(err)
+		return nil, sdk.MarshalResultErr(errRes)
 	}
 	return res, nil
 }
@@ -235,7 +235,7 @@ func queryDelegatorUnbondingDelegations(ctx sdk.Context, cdc *codec.Codec, req a
 
 	res, errRes = codec.MarshalJSONIndent(cdc, unbondingDelegations)
 	if errRes != nil {
-		return nil, sdk.MarshalResultErr(err)
+		return nil, sdk.MarshalResultErr(errRes)
 	}
 	return res, nil
 }
@@ -252,7 +252,7 @@ func queryDelegatorRedelegations(ctx sdk.Context, cdc *codec.Codec, req abci.Req
 
 	res, errRes = codec.MarshalJSONIndent(cdc, redelegations)
 	if errRes != nil {
-		return nil, sdk.MarshalResultErr(err)
+		return nil, sdk.MarshalResultErr(errRes)
 	}
 	return res, nil
 }
@@ -272,7 +272,7 @@ func queryRedelegation(ctx sdk.Context, cdc *codec.Codec, req abci.RequestQuery,
 
 	res, errRes = codec.MarshalJSONIndent(cdc, redelegation)
 	if errRes != nil {
-		return nil, sdk.MarshalResultErr(err)
+		return nil, sdk.MarshalResultErr(errRes)
 	}
 	return res, nil
 }
@@ -291,7 +291,7 @@ func queryDelegatorValidators(ctx sdk.Context, cdc *codec.Codec, req abci.Reques
 
 	res, errRes = codec.MarshalJSONIndent(cdc, validators)
 	if errRes != nil {
-		return nil, sdk.MarshalResultErr(err)
+		return nil, sdk.MarshalResultErr(errRes)
 	}
 	return res, nil
 }
@@ -311,7 +311,7 @@ func queryDelegatorValidator(ctx sdk.Context, cdc *codec.Codec, req abci.Request
 
 	res, errRes = codec.MarshalJSONIndent(cdc, validator)
 	if errRes != nil {
-		return nil, sdk.MarshalResultErr(err)
+		return nil, sdk.MarshalResultErr(errRes)
 	}
 	return res, nil
 }
@@ -331,7 +331,7 @@ func queryDelegation(ctx sdk.Context, cdc *codec.Codec, req abci.RequestQuery, k
 
 	res, errRes = codec.MarshalJSONIndent(cdc, delegation)
 	if errRes != nil {
-		return nil, sdk.MarshalResultErr(err)
+		return nil, sdk.MarshalResultErr(errRes)
 	}
 	return res, nil
 }
@@ -351,7 +351,7 @@ func queryUnbondingDelegation(ctx sdk.Context, cdc *codec.Codec, req abci.Reques
 
 	res, errRes = codec.MarshalJSONIndent(cdc, unbond)
 	if errRes != nil {
-		return nil, sdk.MarshalResultErr(err)
+		return nil, sdk.MarshalResultErr(errRes)
 	}
 	return res, nil
 }
@@ -361,7 +361,7 @@ func queryPool(ctx sdk.Context, cdc *codec.Codec, k keep.Keeper) (res []byte, er
 
 	res, errRes := codec.MarshalJSONIndent(cdc, poolStatus)
 	if errRes != nil {
-		return nil, sdk.MarshalResultErr(err)
+		return nil, sdk.MarshalResultErr(errRes)
 	}
 	return res, nil
 }
@@ -371,7 +371,7 @@ func queryParameters(ctx sdk.Context, cdc *codec.Codec, k keep.Keeper) (res []by
 
 	res, errRes := codec.MarshalJSONIndent(cdc, params)
 	if errRes != nil {
-		return nil, sdk.MarshalResultErr(err)
+		return nil, sdk.MarshalResultErr(errRes)
 	}
 	return res, nil
 }

--- a/tests/cli/bank_test.go
+++ b/tests/cli/bank_test.go
@@ -94,7 +94,7 @@ func TestIrisCLIBankTokenStatsById(t *testing.T) {
 	fooCoin := convertToIrisBaseAccount(t, fooAcc)
 	require.Equal(t, "50iris", fooCoin)
 
-	executeWrite(t, fmt.Sprintf("iriscli asset token issue %v --symbol=kitty --name=eeee --initial-supply=1000 --decimal=0 --from=foo --fee=0.6iris", flags), sdk.DefaultKeyPass)
+	executeWrite(t, fmt.Sprintf("iriscli asset token issue %v --symbol=kitty --name=eeee --initial-supply=1000 --scale=0 --from=foo --fee=0.6iris", flags), sdk.DefaultKeyPass)
 	tests.WaitForNextNBlocksTM(2, port)
 
 	executeWrite(t, fmt.Sprintf("iriscli bank burn --from=foo --amount=10kitty %v --fee=0.6iris", flags), sdk.DefaultKeyPass)


### PR DESCRIPTION
Incorrect input parameter in querier, such as
```go
 if errRes != nil {
	return nil, sdk.MarshalResultErr(err)
}
```