### PR TITLE
R4R: Reset params on upgrading

### DIFF
--- a/app/v3/service/internal/keeper/upgrade.go
+++ b/app/v3/service/internal/keeper/upgrade.go
@@ -7,6 +7,9 @@ import (
 
 // Init initializes the service module
 func (k Keeper) Init(ctx sdk.Context, svcDefinitions []types.ServiceDefinition) {
+	// reset params
+	k.SetParamSet(ctx, types.DefaultParams())
+
 	for _, definition := range svcDefinitions {
 		k.SetServiceDefinition(ctx, definition)
 	}


### PR DESCRIPTION
a new param is added in v3/service module, so reset the param set, other params are equal to the mainnet.