### PR TITLE
R4R: Bump ledger-cosmos-go version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.16.3
+
+*Aug 25th, 2020*
+
+### Application
+
+* [\#4d4c06](https://github.com/irisnet/irishub/commit/4d4c06a6dfdccc4271734ef6eef95960f000384f) Bump ledger-cosmos-go to support cosmos ledger 2.0
+
 ## 0.16.2
 
 *Apr 9th, 2020*

--- a/docs/get-started/install.md
+++ b/docs/get-started/install.md
@@ -6,7 +6,7 @@ order: 2
 
 ## Latest Version
 
-The Latest IRIShub version for Mainnet is [v0.16.2](https://github.com/irisnet/irishub/releases/latest)
+The Latest IRIShub version for Mainnet is [v0.16.3](https://github.com/irisnet/irishub/releases/latest)
 
 ## Install `go`
 
@@ -39,7 +39,7 @@ After setting up `go` correctly, you should be able to compile and run `iris`.
 Make sure that your server can access to google.com because our project depends on some libraries provided by google. (If you are not able to access google.com, you can also try to add a proxy: `export GOPROXY=https://goproxy.io`)
 
 ```bash
-git clone --branch v0.16.2 https://github.com/irisnet/irishub
+git clone --branch v0.16.3 https://github.com/irisnet/irishub
 cd irishub
 # source scripts/setTestEnv.sh # to build or install the testnet version
 make get_tools install

--- a/docs/zh/get-started/install.md
+++ b/docs/zh/get-started/install.md
@@ -6,7 +6,7 @@ order: 2
 
 ## 最新版本
 
-IRIShub 主网的最新版本是[v0.16.2](https://github.com/irisnet/irishub/releases/latest)
+IRIShub 主网的最新版本是[v0.16.3](https://github.com/irisnet/irishub/releases/latest)
 
 ## 安装`go`
 
@@ -39,7 +39,7 @@ go version
 请确保您的服务器可以访问 google.com，因为我们的项目依赖于google提供的某些库（如果您无法访问google.com，也可以尝试添加代理：`export GOPROXY=https://goproxy.io`）
 
 ```bash
-git clone --branch v0.16.2 https://github.com/irisnet/irishub
+git clone --branch v0.16.3 https://github.com/irisnet/irishub
 cd irishub
 # source scripts/setTestEnv.sh # to build or install the testnet version
 make get_tools install

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/bgentry/speakeasy v0.1.0
 	github.com/btcsuite/btcd v0.0.0-20190115013929-ed77733ec07d
 	github.com/cosmos/go-bip39 v0.0.0-20180618194314-52158e4697b8
-	github.com/cosmos/ledger-cosmos-go v0.10.3
+	github.com/cosmos/ledger-cosmos-go v0.11.1
 	github.com/emicklei/proto v1.6.5
 	github.com/go-kit/kit v0.6.0
 	github.com/gogo/protobuf v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46f
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cosmos/go-bip39 v0.0.0-20180618194314-52158e4697b8 h1:Iwin12wRQtyZhH6FV3ykFcdGNlYEzoeR0jN8Vn+JWsI=
 github.com/cosmos/go-bip39 v0.0.0-20180618194314-52158e4697b8/go.mod h1:tSxLoYXyBmiFeKpvmq4dzayMdCjCnu8uqmCysIGBT2Y=
-github.com/cosmos/ledger-cosmos-go v0.10.3 h1:Qhi5yTR5Pg1CaTpd00pxlGwNl4sFRdtK1J96OTjeFFc=
-github.com/cosmos/ledger-cosmos-go v0.10.3/go.mod h1:J8//BsAGTo3OC/vDLjMRFLW6q0WAaXvHnVc7ZmE8iUY=
+github.com/cosmos/ledger-cosmos-go v0.11.1 h1:9JIYsGnXP613pb2vPjFeMMjBI5lEDsEaF6oYorTy6J4=
+github.com/cosmos/ledger-cosmos-go v0.11.1/go.mod h1:J8//BsAGTo3OC/vDLjMRFLW6q0WAaXvHnVc7ZmE8iUY=
 github.com/cosmos/ledger-go v0.9.2 h1:Nnao/dLwaVTk1Q5U9THldpUMMXU94BOTWPddSmVB6pI=
 github.com/cosmos/ledger-go v0.9.2/go.mod h1:oZJ2hHAZROdlHiwTg4t7kP+GKIIkBT+o6c9QWFanOyI=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/lite/swagger-ui/swagger.yaml
+++ b/lite/swagger-ui/swagger.yaml
@@ -4,7 +4,7 @@ info:
   description: >-
     A REST interface for state queries, transaction generation and
     broadcast.
-  version: "0.16.2"
+  version: "0.16.3"
   title: IRISLCD Swagger-UI
   termsOfService: 'https://www.irisnet.org'
   contact:

--- a/version/version.go
+++ b/version/version.go
@@ -11,7 +11,7 @@ import (
 
 // Version - Iris Version
 const ProtocolVersion = 2
-const Version = "0.16.2"
+const Version = "0.16.3"
 
 // GitCommit set by build flags
 var GitCommit = ""


### PR DESCRIPTION
Bump ledger-cosmos-go to support cosmos ledger 2.0

Fixed: #2380 
Closes: #2393 