### PR TITLE
Update install.md ENV variable script 

### DIFF
--- a/docs/get-started/install.md
+++ b/docs/get-started/install.md
@@ -21,7 +21,9 @@ Remember to set your `$GOPATH`, `$GOBIN`, and `$PATH` environment variables, for
 ```bash
 mkdir -p $HOME/go/bin
 echo "export GOPATH=$HOME/go" >> ~/.bashrc
+source ~/.bashrc
 echo "export GOBIN=$GOPATH/bin" >> ~/.bashrc
+source ~/.bashrc
 echo "export PATH=$PATH:$GOBIN" >> ~/.bashrc
 source ~/.bashrc
 ```

--- a/docs/zh/get-started/install.md
+++ b/docs/zh/get-started/install.md
@@ -21,7 +21,9 @@ IRIShub 主网的最新版本是[v0.16.3](https://github.com/irisnet/irishub/rel
 ```bash
 mkdir -p $HOME/go/bin
 echo "export GOPATH=$HOME/go" >> ~/.bashrc
+source ~/.bashrc
 echo "export GOBIN=$GOPATH/bin" >> ~/.bashrc
+source ~/.bashrc
 echo "export PATH=$PATH:$GOBIN" >> ~/.bashrc
 source ~/.bashrc
 ```


### PR DESCRIPTION
Fixes issue that comes from copy/paste the code block as-is since the variables defined in subsequent lines are not yet available when they are appended to `.bashrc`. This results in failure when `make get_tools install` is called due to attempts to install to `/bin` directly rather than `$HOME/go/bin` as we would expect since `$GOPATH` evaluates to an empty string when the `GOBIN` export is evaluated.

https://github.com/cosmos/cosmos-sdk/issues/2973#issuecomment-443404339