### PR TITLE
"make install" to "make"

### DIFF
--- a/docs/get-started/install.md
+++ b/docs/get-started/install.md
@@ -43,7 +43,7 @@ Make sure that your server can access to google.com because our project depends 
 ```bash
 git clone --branch v0.16.3 https://github.com/irisnet/irishub
 cd irishub
-make install
+make
 ```
 
 If your environment variables have set up correctly, you should not get any errors by running the above commands.


### PR DESCRIPTION
In the step below

## Install `iris`

After setting up `go` correctly, you should be able to compile and run `iris`.

Make sure that your server can access to google.com because our project depends on some libraries provided by google. (If you are not able to access google.com, you can also try to add a proxy: `export GOPROXY=https://goproxy.io`)

```bash
git clone --branch v0.16.3 https://github.com/irisnet/irishub
cd irishub
make install 

"make install" command could be change to "make" only, for using in Ubuntu 20.10