### PR TITLE
update github action docker build command

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -13,7 +13,7 @@ jobs:
       - name: build binary by using docker
         run: |
           sed "s/make build/make build-all-binary/g" Dockerfile | tee Dockerfile.all-binary
-          docker build -t build:all-binary -f Dockerfile.all-binary .
+          docker build -t build:all-binary -f Dockerfile.all-binary --build-arg EVM_CHAIN_ID=6688 .
           docker run -itd --name iris-all-binary build:all-binary tail -f /dev/null
           mkdir -p build/
       - name: tar linux amd64 binary


### PR DESCRIPTION
add  --build-arg EVM_CHAIN_ID=6688

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the build process to specify the EVM_CHAIN_ID during docker builds, ensuring compatibility with the intended blockchain environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->