### PR TITLE
fix makefile for github action

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ build-linux: check-evm-chain-id go.sum
 
 build-all-binary: check-evm-chain-id go.sum
 	LEDGER_ENABLED=false GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build $(BUILD_FLAGS) -o build/iris-linux-amd64 ./cmd/iris
-	LEDGER_ENABLED=false GOOS=linux GOARCH=arm64 CGO_ENABLED=1 go build $(BUILD_FLAGS)-o build/iris-linux-arm64 ./cmd/iris
+	LEDGER_ENABLED=false GOOS=linux GOARCH=arm64 CGO_ENABLED=1 go build $(BUILD_FLAGS) -o build/iris-linux-arm64 ./cmd/iris
 	LEDGER_ENABLED=false GOOS=windows GOARCH=amd64 CGO_ENABLED=1 go build $(BUILD_FLAGS) -o build/iris-windows-amd64.exe ./cmd/iris
 
 build-contract-tests-hooks:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved a build issue for the `iris-linux-arm64` target by correcting a command syntax error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->