### PR TITLE
Update CICD releases.yml

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   setup-build-publish:
     name: Setup, Build and Publish
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout Codes
         uses: actions/checkout@v4


### PR DESCRIPTION
downgrade runs-on from ubuntu-latest, ubuntu-22.04, to ubuntu-20.04.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated release workflow to run on Ubuntu 20.04.
  - Included `iris-linux-arm64` build artifact in release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->